### PR TITLE
Migrate from httpx to httpx2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,9 @@ dependencies = [
   "anyio>=4.4.0",
   "beautifulsoup4>=4.12.3",
   "cryptography>=46.0.7",
-  # Note: httpx 0.28.0 depends on httpcore 1.1.x which has a compatibility
-  # issue with Python 3.14's typing.Union. This causes test failures on 3.14.
-  # Workaround: test_shared_client_connection_pooling is marked as xfail on 3.14.
-  # This will be resolved when httpx 0.29.0+ is released (depends on httpcore 1.2.0+).
-  "httpx>=0.28.0",
+  # httpx2: Pydantic's maintained continuation of httpx, built on httpcore2,
+  # which resolves the httpcore 1.1.x / Python 3.14 typing.Union issue.
+  "httpx2>=2.9.1",
   "idna>=3.16",
   "keyring>=25.2.0",
   "keyrings-alt",

--- a/src/shared/http_client.py
+++ b/src/shared/http_client.py
@@ -15,7 +15,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import anyio
-import httpx
+import httpx2
 
 from shared.exceptions import NetworkError
 
@@ -25,21 +25,21 @@ from shared.exceptions import NetworkError
 
 
 def fetch_with_retry_sync(
-  client: httpx.Client,
+  client: httpx2.Client,
   url: str,
   method: str = 'GET',
   max_retries: int = 3,
   backoff_factor: float = 1.0,
   logger: logging.Logger | None = None,
   **kwargs: Any,
-) -> httpx.Response:
+) -> httpx2.Response:
   """Fetch URL with exponential backoff retry logic (sync variant).
 
   Retries on transient errors (connection errors, timeouts, 5xx errors)
   but not on client errors (4xx).
 
   Args:
-    client: httpx.Client instance
+    client: httpx2.Client instance
     url: URL to fetch
     method: HTTP method (default: 'GET')
     max_retries: Maximum number of retry attempts (default: 3)
@@ -48,7 +48,7 @@ def fetch_with_retry_sync(
     **kwargs: Additional arguments to pass to client.request()
 
   Returns:
-    httpx.Response: The successful response
+    httpx2.Response: The successful response
 
   Raises:
     NetworkError: If all retries are exhausted
@@ -64,7 +64,7 @@ def fetch_with_retry_sync(
       response = client.request(method, url, **kwargs)
       response.raise_for_status()
       return response
-    except (httpx.ConnectError, httpx.TimeoutException) as e:
+    except (httpx2.ConnectError, httpx2.TimeoutException) as e:
       last_exception = e
       if attempt == max_retries - 1:
         break
@@ -74,7 +74,7 @@ def fetch_with_retry_sync(
         f'Retrying in {wait_time:.1f}s...',
       )
       time.sleep(wait_time)
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       if 500 <= e.response.status_code < 600:
         last_exception = e
         if attempt == max_retries - 1:
@@ -88,7 +88,7 @@ def fetch_with_retry_sync(
       else:
         # Client errors (4xx) - don't retry, re-raise for caller to handle
         raise
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       last_exception = e
       if attempt == max_retries - 1:
         break
@@ -109,21 +109,21 @@ def fetch_with_retry_sync(
 
 
 async def fetch_with_retry_async(
-  client: httpx.AsyncClient,
+  client: httpx2.AsyncClient,
   url: str,
   method: str = 'GET',
   max_retries: int = 3,
   backoff_factor: float = 1.0,
   logger: logging.Logger | None = None,
   **kwargs: Any,
-) -> httpx.Response:
+) -> httpx2.Response:
   """Fetch URL with exponential backoff retry logic (async variant).
 
   Async version using anyio.sleep() for compatibility with both asyncio
   and trio.
 
   Args:
-    client: httpx.AsyncClient instance
+    client: httpx2.AsyncClient instance
     url: URL to fetch
     method: HTTP method (default: 'GET')
     max_retries: Maximum number of retry attempts (default: 3)
@@ -132,7 +132,7 @@ async def fetch_with_retry_async(
     **kwargs: Additional arguments to pass to client.request()
 
   Returns:
-    httpx.Response: The successful response
+    httpx2.Response: The successful response
 
   Raises:
     NetworkError: If all retries are exhausted
@@ -148,7 +148,7 @@ async def fetch_with_retry_async(
       response = await client.request(method, url, **kwargs)
       response.raise_for_status()
       return response
-    except (httpx.ConnectError, httpx.TimeoutException) as e:
+    except (httpx2.ConnectError, httpx2.TimeoutException) as e:
       last_exception = e
       if attempt == max_retries - 1:
         break
@@ -158,7 +158,7 @@ async def fetch_with_retry_async(
         f'Retrying in {wait_time:.1f}s...',
       )
       await anyio.sleep(wait_time)
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       if 500 <= e.response.status_code < 600:
         last_exception = e
         if attempt == max_retries - 1:
@@ -172,7 +172,7 @@ async def fetch_with_retry_async(
       else:
         # Client errors (4xx) - don't retry, re-raise for caller to handle
         raise
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       last_exception = e
       if attempt == max_retries - 1:
         break
@@ -204,8 +204,8 @@ class BaseHTTPClient(ABC):
   Subclasses implement hooks for package-specific behavior.
   """
 
-  _client: httpx.Client | None = None
-  _shared_client: httpx.Client | None = None
+  _client: httpx2.Client | None = None
+  _shared_client: httpx2.Client | None = None
   _owns_client: bool = False
 
   # ----------------------------------------------------------------------------
@@ -213,13 +213,13 @@ class BaseHTTPClient(ABC):
   # ----------------------------------------------------------------------------
 
   @abstractmethod
-  def _create_client(self) -> httpx.Client:
+  def _create_client(self) -> httpx2.Client:
     """Create and configure an HTTP client.
 
     Subclasses implement this to provide package-specific client configuration.
 
     Returns:
-      Configured httpx.Client instance
+      Configured httpx2.Client instance
     """
 
   def _before_request(
@@ -241,7 +241,7 @@ class BaseHTTPClient(ABC):
       **kwargs: Additional request parameters
     """
 
-  def _after_request(self, response: httpx.Response) -> None:
+  def _after_request(self, response: httpx2.Response) -> None:
     """Hook called after receiving a response.
 
     Default: no-op. Override in subclasses for post-response operations like:
@@ -266,7 +266,7 @@ class BaseHTTPClient(ABC):
   # SHARED IMPLEMENTATIONS
   # ----------------------------------------------------------------------------
 
-  def init_client(self, client: httpx.Client | None = None) -> None:
+  def init_client(self, client: httpx2.Client | None = None) -> None:
     """Initialize or replace the HTTP client.
 
     Three-way logic:
@@ -275,7 +275,7 @@ class BaseHTTPClient(ABC):
     3. Else create new client via _create_client()
 
     Args:
-      client: Optional httpx.Client instance to use
+      client: Optional httpx2.Client instance to use
     """
     if client:
       self._client = client
@@ -327,8 +327,8 @@ class AsyncBaseHTTPClient(ABC):
   Async version of BaseHTTPClient with same pattern but async methods.
   """
 
-  _client: httpx.AsyncClient | None = None
-  _shared_client: httpx.AsyncClient | None = None
+  _client: httpx2.AsyncClient | None = None
+  _shared_client: httpx2.AsyncClient | None = None
   _owns_client: bool = False
 
   # ----------------------------------------------------------------------------
@@ -336,11 +336,11 @@ class AsyncBaseHTTPClient(ABC):
   # ----------------------------------------------------------------------------
 
   @abstractmethod
-  async def _create_client(self) -> httpx.AsyncClient:
+  async def _create_client(self) -> httpx2.AsyncClient:
     """Create and configure an async HTTP client.
 
     Args:
-      Returns: Configured httpx.AsyncClient instance
+      Returns: Configured httpx2.AsyncClient instance
     """
 
   async def _before_request(
@@ -354,7 +354,7 @@ class AsyncBaseHTTPClient(ABC):
     Default: no-op. Override for pre-request operations.
     """
 
-  async def _after_request(self, response: httpx.Response) -> None:
+  async def _after_request(self, response: httpx2.Response) -> None:
     """Hook called after receiving a response.
 
     Default: no-op. Override for post-response operations.
@@ -370,7 +370,7 @@ class AsyncBaseHTTPClient(ABC):
   # SHARED IMPLEMENTATIONS
   # ----------------------------------------------------------------------------
 
-  async def init_client(self, client: httpx.AsyncClient | None = None) -> None:
+  async def init_client(self, client: httpx2.AsyncClient | None = None) -> None:
     """Initialize or replace the async HTTP client.
 
     Three-way logic:
@@ -379,7 +379,7 @@ class AsyncBaseHTTPClient(ABC):
     3. Else create new client via _create_client()
 
     Args:
-      client: Optional httpx.AsyncClient instance to use
+      client: Optional httpx2.AsyncClient instance to use
     """
     if client:
       self._client = client

--- a/src/zdatafetch/activity.py
+++ b/src/zdatafetch/activity.py
@@ -6,7 +6,7 @@ Provides access to activity history from Zwift's unofficial API.
 import json
 from typing import Any
 
-import httpx
+import httpx2
 
 from shared.exceptions import ConfigError, NetworkError
 from shared.json_helpers import parse_json_safe
@@ -110,7 +110,7 @@ class ZwiftActivity:
     params = {'start': start, 'limit': limit}
 
     try:
-      with httpx.Client() as client:
+      with httpx2.Client() as client:
         response = client.get(url, headers=headers, params=params, timeout=30.0)
 
         if response.status_code == 404:
@@ -130,11 +130,11 @@ class ZwiftActivity:
           f'Successfully fetched {len(self.activities)} activities for rider {rider_id}',
         )
 
-    except httpx.TimeoutException as e:
+    except httpx2.TimeoutException as e:
       raise NetworkError(
         f'Request timed out fetching activities for rider {rider_id}: {e}',
       ) from e
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
       raise NetworkError(
         f'Network error fetching activities for rider {rider_id}: {e}',
       ) from e
@@ -188,7 +188,7 @@ class ZwiftActivity:
 
     # Fetch all activities
     results = {}
-    with httpx.Client() as client:
+    with httpx2.Client() as client:
       for rider_id in rider_ids:
         try:
           url = f'{cls.BASE_URL}/api/profiles/{rider_id}/activities/'

--- a/src/zdatafetch/auth.py
+++ b/src/zdatafetch/auth.py
@@ -7,7 +7,7 @@ token acquisition, storage, and automatic refresh.
 import time
 from typing import Any
 
-import httpx
+import httpx2
 
 from shared.exceptions import AuthenticationError, NetworkError
 from zdatafetch.logging_config import get_logger
@@ -75,7 +75,7 @@ class ZwiftAuth:
     }
 
     try:
-      with httpx.Client() as client:
+      with httpx2.Client() as client:
         response = client.post(self.AUTH_URL, data=data, timeout=30.0)
 
         if response.status_code == 401:
@@ -91,9 +91,9 @@ class ZwiftAuth:
         f'Authentication successful (token expires in {self.expires_in}s)',
       )
 
-    except httpx.TimeoutException as e:
+    except httpx2.TimeoutException as e:
       raise NetworkError(f'Authentication request timed out: {e}') from e
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
       raise NetworkError(f'Authentication request failed: {e}') from e
 
   def _parse_token_response(self, token_data: dict[str, Any]) -> None:
@@ -162,7 +162,7 @@ class ZwiftAuth:
     }
 
     try:
-      with httpx.Client() as client:
+      with httpx2.Client() as client:
         response = client.post(self.AUTH_URL, data=data, timeout=30.0)
 
         if response.status_code == 401:
@@ -178,9 +178,9 @@ class ZwiftAuth:
 
       logger.debug('Token refreshed successfully')
 
-    except httpx.TimeoutException as e:
+    except httpx2.TimeoutException as e:
       raise NetworkError(f'Token refresh request timed out: {e}') from e
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
       raise NetworkError(f'Token refresh request failed: {e}') from e
 
   def is_authenticated(self) -> bool:

--- a/src/zdatafetch/followers.py
+++ b/src/zdatafetch/followers.py
@@ -6,7 +6,7 @@ Provides access to follower/followee relationship data from Zwift's unofficial A
 import json
 from typing import Any
 
-import httpx
+import httpx2
 
 from shared.exceptions import ConfigError, NetworkError
 from shared.json_helpers import parse_json_safe
@@ -112,7 +112,7 @@ class ZwiftFollowers:
     raw_data = {}
 
     try:
-      with httpx.Client() as client:
+      with httpx2.Client() as client:
         # Fetch followers
         if include_followers:
           url = f'{self.BASE_URL}/api/profiles/{rider_id}/followers'
@@ -154,11 +154,11 @@ class ZwiftFollowers:
         self._raw = json.dumps(self._fetched, indent=2)
         logger.info(f'Successfully fetched follower data for rider {rider_id}')
 
-    except httpx.TimeoutException as e:
+    except httpx2.TimeoutException as e:
       raise NetworkError(
         f'Request timed out fetching follower data for rider {rider_id}: {e}',
       ) from e
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
       raise NetworkError(
         f'Network error fetching follower data for rider {rider_id}: {e}',
       ) from e
@@ -218,7 +218,7 @@ class ZwiftFollowers:
 
     # Fetch all follower data
     results = {}
-    with httpx.Client() as client:
+    with httpx2.Client() as client:
       for rider_id in rider_ids:
         try:
           raw_data = {}

--- a/src/zdatafetch/profile.py
+++ b/src/zdatafetch/profile.py
@@ -7,7 +7,7 @@ including demographics, statistics, and connected services.
 import json
 from typing import Any
 
-import httpx
+import httpx2
 
 from shared.exceptions import ConfigError, NetworkError
 from shared.json_helpers import parse_json_safe
@@ -199,7 +199,7 @@ class ZwiftProfile:
     headers = {'Authorization': f'Bearer {token}', 'Accept': 'application/json'}
 
     try:
-      with httpx.Client() as client:
+      with httpx2.Client() as client:
         response = client.get(url, headers=headers, timeout=30.0)
 
         if response.status_code == 404:
@@ -217,11 +217,11 @@ class ZwiftProfile:
         self._parse_response()
         logger.info(f'Successfully fetched profile for rider {rider_id}')
 
-    except httpx.TimeoutException as e:
+    except httpx2.TimeoutException as e:
       raise NetworkError(
         f'Request timed out fetching profile for rider {rider_id}: {e}',
       ) from e
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
       raise NetworkError(
         f'Network error fetching profile for rider {rider_id}: {e}',
       ) from e
@@ -268,7 +268,7 @@ class ZwiftProfile:
 
     # Fetch all profiles
     results = {}
-    with httpx.Client() as client:
+    with httpx2.Client() as client:
       for rider_id in rider_ids:
         try:
           url = f'{cls.BASE_URL}/api/profiles/{rider_id}'

--- a/src/zdatafetch/rideons.py
+++ b/src/zdatafetch/rideons.py
@@ -7,7 +7,7 @@ fetching RideOns received on activities and giving RideOns.
 import json
 from typing import Any
 
-import httpx
+import httpx2
 
 from shared.exceptions import ConfigError, NetworkError
 from shared.json_helpers import parse_json_safe
@@ -109,7 +109,7 @@ class ZwiftRideOns:
     url = f'{self.BASE_URL}/api/profiles/{rider_id}/activities/{activity_id}/rideons'
 
     try:
-      with httpx.Client() as client:
+      with httpx2.Client() as client:
         response = client.get(url, headers=headers, timeout=30.0)
 
         if response.status_code == 404:
@@ -131,11 +131,11 @@ class ZwiftRideOns:
           f'Successfully fetched RideOns for activity {activity_id} (rider {rider_id})',
         )
 
-    except httpx.TimeoutException as e:
+    except httpx2.TimeoutException as e:
       raise NetworkError(
         f'Request timed out fetching RideOns for activity {activity_id}: {e}',
       ) from e
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
       raise NetworkError(
         f'Network error fetching RideOns for activity {activity_id}: {e}',
       ) from e
@@ -187,7 +187,7 @@ class ZwiftRideOns:
 
     # Fetch all RideOns
     results = {}
-    with httpx.Client() as client:
+    with httpx2.Client() as client:
       for rider_id, activity_id in activity_tuples:
         try:
           url = f'{cls.BASE_URL}/api/profiles/{rider_id}/activities/{activity_id}/rideons'
@@ -261,7 +261,7 @@ class ZwiftRideOns:
     url = f'{ZwiftRideOns.BASE_URL}/api/profiles/{rider_id}/activities/{activity_id}/rideon'
 
     try:
-      with httpx.Client() as client:
+      with httpx2.Client() as client:
         response = client.post(url, headers=headers, timeout=30.0)
 
         if response.status_code in (200, 201, 204):
@@ -280,12 +280,12 @@ class ZwiftRideOns:
         )
         return False
 
-    except httpx.TimeoutException as e:
+    except httpx2.TimeoutException as e:
       logger.error(
         f'Request timed out giving RideOn to activity {activity_id}: {e}',
       )
       return False
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
       logger.error(
         f'Network error giving RideOn to activity {activity_id}: {e}',
       )

--- a/src/zdatafetch/ridersinworld.py
+++ b/src/zdatafetch/ridersinworld.py
@@ -6,7 +6,7 @@ Provides access to riders currently in a specific world from Zwift's unofficial 
 import json
 from typing import Any
 
-import httpx
+import httpx2
 
 from shared.exceptions import ConfigError, NetworkError
 from shared.json_helpers import parse_json_safe
@@ -99,7 +99,7 @@ class ZwiftRidersInWorld:
     url = f'{self.BASE_URL}/relay/worlds/{world_id}'
 
     try:
-      with httpx.Client() as client:
+      with httpx2.Client() as client:
         response = client.get(url, headers=headers, timeout=30.0)
 
         if response.status_code == 404:
@@ -119,11 +119,11 @@ class ZwiftRidersInWorld:
           f'Successfully fetched {len(self.riders)} riders in world {world_id}',
         )
 
-    except httpx.TimeoutException as e:
+    except httpx2.TimeoutException as e:
       raise NetworkError(
         f'Request timed out fetching riders for world {world_id}: {e}',
       ) from e
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
       raise NetworkError(
         f'Network error fetching riders for world {world_id}: {e}',
       ) from e
@@ -195,7 +195,7 @@ class ZwiftRidersInWorld:
 
     # Fetch all riders
     results = {}
-    with httpx.Client() as client:
+    with httpx2.Client() as client:
       for world_id in world_ids:
         try:
           url = f'{cls.BASE_URL}/relay/worlds/{world_id}'

--- a/src/zdatafetch/worlds.py
+++ b/src/zdatafetch/worlds.py
@@ -6,7 +6,7 @@ Provides access to active worlds from Zwift's unofficial API.
 import json
 from typing import Any
 
-import httpx
+import httpx2
 
 from shared.exceptions import ConfigError, NetworkError
 from shared.json_helpers import parse_json_safe
@@ -129,7 +129,7 @@ class ZwiftWorlds:
     url = f'{self.BASE_URL}/relay/worlds'
 
     try:
-      with httpx.Client() as client:
+      with httpx2.Client() as client:
         response = client.get(url, headers=headers, timeout=30.0)
 
         if response.status_code != 200:
@@ -144,9 +144,9 @@ class ZwiftWorlds:
         self._raw = json.dumps(self._fetched, indent=2)
         logger.info(f'Successfully fetched {len(self.worlds)} active worlds')
 
-    except httpx.TimeoutException as e:
+    except httpx2.TimeoutException as e:
       raise NetworkError(f'Request timed out fetching worlds: {e}') from e
-    except httpx.HTTPError as e:
+    except httpx2.HTTPError as e:
       raise NetworkError(f'Network error fetching worlds: {e}') from e
 
   def _parse_response(self, raw_json: str) -> None:

--- a/src/zpdatafetch/async_zp.py
+++ b/src/zpdatafetch/async_zp.py
@@ -6,7 +6,7 @@ allowing for concurrent requests and better performance in async applications.
 
 from typing import Any
 
-import httpx
+import httpx2
 from bs4 import BeautifulSoup
 
 from shared.error_helpers import format_auth_error, format_network_error
@@ -46,11 +46,9 @@ class AsyncZP(AsyncBaseHTTPClient):
     login_response: Response from the login POST request
   """
 
-  _client: httpx.AsyncClient | None = None
-  _login_url: str = (
-    'https://zwiftpower.com/ucp.php?mode=login&login=external&oauth_service=oauthzpsso'
-  )
-  _shared_client: httpx.AsyncClient | None = None
+  _client: httpx2.AsyncClient | None = None
+  _login_url: str = 'https://zwiftpower.com/ucp.php?mode=login&login=external&oauth_service=oauthzpsso'
+  _shared_client: httpx2.AsyncClient | None = None
   _owns_client: bool = False
 
   # ----------------------------------------------------------------------------
@@ -73,7 +71,7 @@ class AsyncZP(AsyncBaseHTTPClient):
     self.config.load()
     self.username: str = self.config.username
     self.password: str = self.config.password
-    self.login_response: httpx.Response | None = None
+    self.login_response: httpx2.Response | None = None
 
     if not skip_credential_check and (not self.username or not self.password):
       raise ConfigError(
@@ -85,7 +83,7 @@ class AsyncZP(AsyncBaseHTTPClient):
     # This ensures _shared_client is available for tests
     if shared_client and AsyncZP._shared_client is None:
       logger.debug('Creating shared async HTTP client for connection pooling')
-      AsyncZP._shared_client = httpx.AsyncClient(
+      AsyncZP._shared_client = httpx2.AsyncClient(
         follow_redirects=True,
         verify=True,
       )
@@ -131,7 +129,7 @@ class AsyncZP(AsyncBaseHTTPClient):
       logger.debug(f'Fetching url: {self._login_url}')
       page = await self._client.get(self._login_url)
       page.raise_for_status()
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(f'Failed to fetch login page: {e}')
       raise NetworkError(
         format_network_error(
@@ -141,7 +139,7 @@ class AsyncZP(AsyncBaseHTTPClient):
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error during login: {e}')
       raise NetworkError(
         format_network_error('fetch login page', self._login_url, e),
@@ -204,7 +202,7 @@ class AsyncZP(AsyncBaseHTTPClient):
           ),
         )
       logger.info('Successfully authenticated with Zwiftpower')
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(f'HTTP error during authentication: {e}')
       raise NetworkError(
         format_network_error(
@@ -214,7 +212,7 @@ class AsyncZP(AsyncBaseHTTPClient):
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error during authentication: {e}')
       raise NetworkError(
         format_network_error(
@@ -225,20 +223,20 @@ class AsyncZP(AsyncBaseHTTPClient):
       ) from e
 
   # ----------------------------------------------------------------------------
-  async def _create_client(self) -> httpx.AsyncClient:
+  async def _create_client(self) -> httpx2.AsyncClient:
     """Create and configure an async HTTP client.
 
     SECURITY: All connections use HTTPS with certificate verification enabled.
     This protects against man-in-the-middle attacks.
 
     Returns:
-      Configured httpx.AsyncClient instance
+      Configured httpx2.AsyncClient instance
     """
     logger.debug(
       'Creating new httpx async client with HTTPS certificate verification',
     )
     # SECURITY: Explicitly enable certificate verification for HTTPS
-    return httpx.AsyncClient(follow_redirects=True, verify=True)
+    return httpx2.AsyncClient(follow_redirects=True, verify=True)
 
   # ----------------------------------------------------------------------------
   async def _before_request(
@@ -308,10 +306,13 @@ class AsyncZP(AsyncBaseHTTPClient):
       return res
     except NetworkError:
       raise
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.debug(f'HTTP error fetching {endpoint}: {e}')
       # Special handling for 403 on cyclist profile URLs
-      if e.response.status_code == 403 and 'zwiftpower.com/cache3/profile/' in endpoint:
+      if (
+        e.response.status_code == 403
+        and 'zwiftpower.com/cache3/profile/' in endpoint
+      ):
         raise NetworkError(
           format_network_error(
             'fetch Zwift profile',
@@ -328,7 +329,7 @@ class AsyncZP(AsyncBaseHTTPClient):
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error fetching {endpoint}: {e}')
       raise NetworkError(
         format_network_error('fetch JSON data', endpoint, e),
@@ -371,7 +372,7 @@ class AsyncZP(AsyncBaseHTTPClient):
       return pres.text
     except NetworkError:
       raise
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(f'HTTP error fetching {endpoint}: {e}')
       raise NetworkError(
         format_network_error(
@@ -381,7 +382,7 @@ class AsyncZP(AsyncBaseHTTPClient):
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error fetching {endpoint}: {e}')
       raise NetworkError(
         format_network_error('fetch page', endpoint, e),
@@ -405,7 +406,7 @@ class AsyncZP(AsyncBaseHTTPClient):
     max_retries: int = 3,
     backoff_factor: float = 1.0,
     **kwargs: Any,
-  ) -> httpx.Response:
+  ) -> httpx2.Response:
     """Compatibility wrapper for fetch_with_retry_async.
 
     Deprecated: Use fetch_with_retry_async() directly. This method exists

--- a/src/zpdatafetch/zp.py
+++ b/src/zpdatafetch/zp.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-import httpx
+import httpx2
 from bs4 import BeautifulSoup
 
 from shared.error_helpers import format_auth_error, format_network_error
@@ -29,11 +29,9 @@ class ZP(BaseHTTPClient):
     login_response: Response from the login POST request
   """
 
-  _client: httpx.Client | None = None
-  _login_url: str = (
-    'https://zwiftpower.com/ucp.php?mode=login&login=external&oauth_service=oauthzpsso'
-  )
-  _shared_client: httpx.Client | None = None
+  _client: httpx2.Client | None = None
+  _login_url: str = 'https://zwiftpower.com/ucp.php?mode=login&login=external&oauth_service=oauthzpsso'
+  _shared_client: httpx2.Client | None = None
   _owns_client: bool = False
 
   # ----------------------------------------------------------------------------
@@ -56,7 +54,7 @@ class ZP(BaseHTTPClient):
     self.config.load()
     self.username: str = self.config.username
     self.password: str = self.config.password
-    self.login_response: httpx.Response | None = None
+    self.login_response: httpx2.Response | None = None
 
     if not skip_credential_check and (not self.username or not self.password):
       raise ConfigError(
@@ -109,7 +107,7 @@ class ZP(BaseHTTPClient):
       logger.debug(f'Fetching url: {self._login_url}')
       page = self._client.get(self._login_url)
       page.raise_for_status()
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(f'Failed to fetch login page: {e}')
       raise NetworkError(
         format_network_error(
@@ -119,7 +117,7 @@ class ZP(BaseHTTPClient):
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error during login: {e}')
       raise NetworkError(
         format_network_error('fetch login page', self._login_url, e),
@@ -183,7 +181,7 @@ class ZP(BaseHTTPClient):
           ),
         )
       logger.info('Successfully authenticated with Zwiftpower')
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(f'HTTP error during authentication: {e}')
       raise NetworkError(
         format_network_error(
@@ -193,7 +191,7 @@ class ZP(BaseHTTPClient):
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error during authentication: {e}')
       raise NetworkError(
         format_network_error(
@@ -204,20 +202,20 @@ class ZP(BaseHTTPClient):
       ) from e
 
   # ----------------------------------------------------------------------------
-  def _create_client(self) -> httpx.Client:
+  def _create_client(self) -> httpx2.Client:
     """Create and configure an HTTP client.
 
     SECURITY: All connections use HTTPS with certificate verification enabled.
     This protects against man-in-the-middle attacks.
 
     Returns:
-      Configured httpx.Client instance
+      Configured httpx2.Client instance
     """
     logger.debug(
       'Creating new httpx client with HTTPS certificate verification',
     )
     # SECURITY: Explicitly enable certificate verification for HTTPS connections
-    return httpx.Client(follow_redirects=True, verify=True)
+    return httpx2.Client(follow_redirects=True, verify=True)
 
   # ----------------------------------------------------------------------------
   def _before_request(
@@ -283,7 +281,7 @@ class ZP(BaseHTTPClient):
       return res
     except NetworkError:
       raise
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(f'HTTP error fetching {endpoint}: {e}')
       raise NetworkError(
         format_network_error(
@@ -293,7 +291,7 @@ class ZP(BaseHTTPClient):
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error fetching {endpoint}: {e}')
       raise NetworkError(
         format_network_error('fetch JSON data', endpoint, e),
@@ -334,7 +332,7 @@ class ZP(BaseHTTPClient):
       return res
     except NetworkError:
       raise
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(f'HTTP error fetching {endpoint}: {e}')
       raise NetworkError(
         format_network_error(
@@ -344,7 +342,7 @@ class ZP(BaseHTTPClient):
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error fetching {endpoint}: {e}')
       raise NetworkError(
         format_network_error('fetch page', endpoint, e),
@@ -387,7 +385,7 @@ class ZP(BaseHTTPClient):
     max_retries: int = 3,
     backoff_factor: float = 1.0,
     **kwargs: Any,
-  ) -> httpx.Response:
+  ) -> httpx2.Response:
     """Compatibility wrapper for fetch_with_retry_sync.
 
     Deprecated: Use fetch_with_retry_sync() directly. This method exists

--- a/src/zrdatafetch/async_zr.py
+++ b/src/zrdatafetch/async_zr.py
@@ -7,7 +7,7 @@ allowing for concurrent requests and better performance in async applications.
 from typing import Any
 
 import anyio
-import httpx
+import httpx2
 
 from shared.error_helpers import format_network_error
 from shared.exceptions import NetworkError
@@ -35,11 +35,11 @@ class AsyncZR_obj:
 
   Attributes:
     _base_url: Base URL for Zwiftracing API
-    _client: httpx.AsyncClient instance
+    _client: httpx2.AsyncClient instance
   """
 
   _base_url: str = 'https://api.zwiftracing.app/api'
-  _shared_client: httpx.AsyncClient | None = None
+  _shared_client: httpx2.AsyncClient | None = None
   _owns_client: bool = False
 
   # ----------------------------------------------------------------------------
@@ -57,13 +57,13 @@ class AsyncZR_obj:
       premium: Use premium tier rate limits (default: False for
         standard tier).
     """
-    self._client: httpx.AsyncClient | None = None
+    self._client: httpx2.AsyncClient | None = None
     self._owns_client = not shared_client
     self.rate_limiter = RateLimiter(tier='premium' if premium else 'standard')
 
     if shared_client and AsyncZR_obj._shared_client is None:
       logger.debug('Creating shared async HTTP client for connection pooling')
-      AsyncZR_obj._shared_client = httpx.AsyncClient(
+      AsyncZR_obj._shared_client = httpx2.AsyncClient(
         base_url=self._base_url,
         timeout=30.0,
         follow_redirects=True,
@@ -72,12 +72,12 @@ class AsyncZR_obj:
   # ----------------------------------------------------------------------------
   async def init_client(
     self,
-    client: httpx.AsyncClient | None = None,
+    client: httpx2.AsyncClient | None = None,
   ) -> None:
     """Initialize or replace the async HTTP client.
 
     Args:
-      client: Optional httpx.AsyncClient instance to use. If None, uses shared
+      client: Optional httpx2.AsyncClient instance to use. If None, uses shared
         client if available, otherwise creates a new client.
     """
     logger.debug('Initializing httpx async client for Zwiftracing')
@@ -93,7 +93,7 @@ class AsyncZR_obj:
         'Creating new httpx async client with HTTPS certificate verification',
       )
       # SECURITY: Explicitly enable certificate verification for HTTPS
-      self._client = httpx.AsyncClient(
+      self._client = httpx2.AsyncClient(
         base_url=self._base_url,
         timeout=30.0,
         follow_redirects=True,
@@ -108,7 +108,7 @@ class AsyncZR_obj:
     max_retries: int = 3,
     backoff_factor: float = 1.0,
     **kwargs: Any,
-  ) -> httpx.Response:
+  ) -> httpx2.Response:
     """Fetch endpoint with exponential backoff retry logic (async).
 
     Retries on transient errors (connection errors, timeouts) but not on
@@ -123,7 +123,7 @@ class AsyncZR_obj:
       **kwargs: Additional arguments to pass to httpx client method
 
     Returns:
-      httpx.Response: The successful response
+      httpx2.Response: The successful response
 
     Raises:
       NetworkError: If all retries are exhausted or rate limit exceeded
@@ -150,7 +150,7 @@ class AsyncZR_obj:
         self.rate_limiter.record_request(endpoint_type)
         return response
 
-      except (httpx.ConnectError, httpx.TimeoutException) as e:
+      except (httpx2.ConnectError, httpx2.TimeoutException) as e:
         last_exception = e
         if attempt == max_retries - 1:
           break
@@ -161,7 +161,7 @@ class AsyncZR_obj:
         )
         await anyio.sleep(wait_time)
 
-      except httpx.HTTPStatusError as e:
+      except httpx2.HTTPStatusError as e:
         # Handle rate limit error (429)
         if e.response.status_code == 429:
           tier = self.rate_limiter.tier
@@ -191,7 +191,7 @@ class AsyncZR_obj:
             ),
           ) from e
 
-      except httpx.RequestError as e:
+      except httpx2.RequestError as e:
         last_exception = e
         if attempt == max_retries - 1:
           break
@@ -242,7 +242,7 @@ class AsyncZR_obj:
 
     Raises:
       NetworkError: If the HTTP request fails after retries
-      httpx.HTTPStatusError: If response has error status
+      httpx2.HTTPStatusError: If response has error status
 
     Example:
       # GET request
@@ -272,7 +272,7 @@ class AsyncZR_obj:
       return res
     except NetworkError:
       raise
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(f'HTTP error fetching {endpoint}: {e}')
       raise NetworkError(
         format_network_error(
@@ -282,7 +282,7 @@ class AsyncZR_obj:
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error fetching {endpoint}: {e}')
       raise NetworkError(
         format_network_error('fetch JSON data', endpoint, e),

--- a/src/zrdatafetch/zr.py
+++ b/src/zrdatafetch/zr.py
@@ -7,7 +7,7 @@ serialization for all Zwiftracing data classes.
 import json
 from typing import Any, ClassVar
 
-import httpx
+import httpx2
 
 from shared.error_helpers import format_network_error
 from shared.exceptions import NetworkError
@@ -33,13 +33,13 @@ class ZR_obj:
     _premium_mode: Class-level setting for premium tier rate limits
   """
 
-  _client: ClassVar[httpx.Client | None] = None
+  _client: ClassVar[httpx2.Client | None] = None
   _base_url: ClassVar[str] = 'https://api.zwiftracing.app/api'
   _premium_mode: ClassVar[bool] = False  # Default to standard tier
 
   # ----------------------------------------------------------------------------
   @classmethod
-  def get_client(cls) -> httpx.Client:
+  def get_client(cls) -> httpx2.Client:
     """Get or create a shared HTTP client.
 
     Creates a single shared client for connection pooling across all
@@ -47,11 +47,11 @@ class ZR_obj:
     API requests.
 
     Returns:
-      httpx.Client instance configured for Zwiftracing API
+      httpx2.Client instance configured for Zwiftracing API
     """
     if cls._client is None:
       logger.debug('Creating shared HTTP client for Zwiftracing')
-      cls._client = httpx.Client(
+      cls._client = httpx2.Client(
         base_url=cls._base_url,
         timeout=30.0,
         follow_redirects=True,
@@ -111,7 +111,7 @@ class ZR_obj:
       endpoint: API endpoint path (e.g., '/public/riders/123')
       method: HTTP method ('GET' or 'POST'). Default: 'GET'
       premium: Use premium tier rate limits (default: False for standard)
-      **kwargs: Additional arguments passed to httpx.get() or httpx.post()
+      **kwargs: Additional arguments passed to httpx2.get() or httpx2.post()
         (e.g., headers, params, json, etc.)
 
     Returns:
@@ -170,7 +170,7 @@ class ZR_obj:
       rate_limiter.record_request(endpoint_type)
       return response.text
 
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(f'HTTP error {method} {endpoint}: {e.response.status_code}')
       raise NetworkError(
         format_network_error(
@@ -180,7 +180,7 @@ class ZR_obj:
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error {method} {endpoint}: {e}')
       raise NetworkError(
         format_network_error(f'{method.lower()} request', endpoint, e),

--- a/src/zsdatafetch/async_zs.py
+++ b/src/zsdatafetch/async_zs.py
@@ -6,7 +6,7 @@ This API is public and unauthenticated.
 
 from typing import Any, ClassVar
 
-import httpx
+import httpx2
 
 from shared.error_helpers import format_network_error
 from shared.exceptions import NetworkError
@@ -35,7 +35,7 @@ class AsyncZS_obj:
 
   def __init__(self) -> None:
     """Initialize AsyncZS_obj."""
-    self._client: httpx.AsyncClient | None = None
+    self._client: httpx2.AsyncClient | None = None
 
   async def init_client(self) -> None:
     """Initialize the async HTTP client."""
@@ -43,7 +43,7 @@ class AsyncZS_obj:
       logger.debug(
         'Creating async HTTP client for Zwift Status',
       )
-      self._client = httpx.AsyncClient(
+      self._client = httpx2.AsyncClient(
         timeout=30.0,
         follow_redirects=True,
       )
@@ -90,20 +90,24 @@ class AsyncZS_obj:
 
     try:
       response = await fetch_with_retry_async(
-        self._client, url, logger=logger,
+        self._client,
+        url,
+        logger=logger,
       )
       return response.text
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(
         f'HTTP error GET {endpoint}: {e.response.status_code}',
       )
       raise NetworkError(
         format_network_error(
-          'get request', endpoint, e,
+          'get request',
+          endpoint,
+          e,
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error GET {endpoint}: {e}')
       raise NetworkError(
         format_network_error('get request', endpoint, e),

--- a/src/zsdatafetch/zs.py
+++ b/src/zsdatafetch/zs.py
@@ -6,7 +6,7 @@ This API is public and unauthenticated.
 
 from typing import ClassVar
 
-import httpx
+import httpx2
 
 from shared.error_helpers import format_network_error
 from shared.exceptions import NetworkError
@@ -31,19 +31,19 @@ class ZS_obj:
     _base_url: Base URL for all API requests
   """
 
-  _client: ClassVar[httpx.Client | None] = None
+  _client: ClassVar[httpx2.Client | None] = None
   _base_url: ClassVar[str] = 'https://status.zwift.com/api/v2'
 
   @classmethod
-  def get_client(cls) -> httpx.Client:
+  def get_client(cls) -> httpx2.Client:
     """Get or create a shared HTTP client.
 
     Returns:
-      httpx.Client configured for Zwift Status API
+      httpx2.Client configured for Zwift Status API
     """
     if cls._client is None:
       logger.debug('Creating shared HTTP client for Zwift Status')
-      cls._client = httpx.Client(
+      cls._client = httpx2.Client(
         timeout=30.0,
         follow_redirects=True,
       )
@@ -74,20 +74,24 @@ class ZS_obj:
 
     try:
       response = fetch_with_retry_sync(
-        client, url, logger=logger,
+        client,
+        url,
+        logger=logger,
       )
       return response.text
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
       logger.error(
         f'HTTP error GET {endpoint}: {e.response.status_code}',
       )
       raise NetworkError(
         format_network_error(
-          'get request', endpoint, e,
+          'get request',
+          endpoint,
+          e,
           status_code=e.response.status_code,
         ),
       ) from e
-    except httpx.RequestError as e:
+    except httpx2.RequestError as e:
       logger.error(f'Network error GET {endpoint}: {e}')
       raise NetworkError(
         format_network_error('get request', endpoint, e),

--- a/test/test_zdatafetch/conftest.py
+++ b/test/test_zdatafetch/conftest.py
@@ -164,7 +164,7 @@ def mock_profile_not_found():
 @pytest.fixture
 def auth_handler(mock_token_response):
   """HTTP handler for authentication requests."""
-  import httpx
+  import httpx2
 
   def handler(request):
     if 'auth/realms/zwift/tokens/access/codes' in str(request.url):
@@ -173,12 +173,12 @@ def auth_handler(mock_token_response):
         body = request.content.decode('utf-8')
         if 'grant_type=password' in body:
           # Initial login
-          return httpx.Response(200, text=json.dumps(mock_token_response))
+          return httpx2.Response(200, text=json.dumps(mock_token_response))
         if 'grant_type=refresh_token' in body:
           # Token refresh
-          return httpx.Response(200, text=json.dumps(mock_token_response))
-        return httpx.Response(400, text='Invalid grant_type')
-    return httpx.Response(404)
+          return httpx2.Response(200, text=json.dumps(mock_token_response))
+        return httpx2.Response(400, text='Invalid grant_type')
+    return httpx2.Response(404)
 
   return handler
 
@@ -186,25 +186,25 @@ def auth_handler(mock_token_response):
 @pytest.fixture
 def profile_handler(mock_profile_data):
   """HTTP handler for profile requests."""
-  import httpx
+  import httpx2
 
   def handler(request):
     if '/api/profiles/' in str(request.url):
       # Check for authorization header
       if 'Authorization' not in request.headers:
-        return httpx.Response(401, text='Unauthorized')
+        return httpx2.Response(401, text='Unauthorized')
 
       # Extract rider ID from URL
       url_parts = str(request.url).split('/')
       rider_id = url_parts[-1]
 
       if rider_id == '550564':
-        return httpx.Response(200, text=json.dumps(mock_profile_data))
+        return httpx2.Response(200, text=json.dumps(mock_profile_data))
       if rider_id == '999999':
-        return httpx.Response(404, text='Profile not found')
-      return httpx.Response(200, text=json.dumps(mock_profile_data))
+        return httpx2.Response(404, text='Profile not found')
+      return httpx2.Response(200, text=json.dumps(mock_profile_data))
 
-    return httpx.Response(404)
+    return httpx2.Response(404)
 
   return handler
 
@@ -212,7 +212,7 @@ def profile_handler(mock_profile_data):
 @pytest.fixture
 def combined_handler(auth_handler, profile_handler):
   """Combined HTTP handler for auth and profile requests."""
-  import httpx
+  import httpx2
 
   def handler(request):
     # Try auth handler first
@@ -221,6 +221,6 @@ def combined_handler(auth_handler, profile_handler):
     # Then try profile handler
     if '/api/profiles/' in str(request.url):
       return profile_handler(request)
-    return httpx.Response(404)
+    return httpx2.Response(404)
 
   return handler

--- a/test/test_zdatafetch/test_auth.py
+++ b/test/test_zdatafetch/test_auth.py
@@ -2,7 +2,7 @@
 
 import time
 
-import httpx
+import httpx2
 import pytest
 
 from shared.exceptions import AuthenticationError, NetworkError
@@ -29,12 +29,12 @@ def test_login_success(mock_auth, auth_handler, mock_token_response):
   # Mock the httpx client
   import zdatafetch.auth
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(auth_handler))
+    return original_client(transport=httpx2.MockTransport(auth_handler))
 
-  zdatafetch.auth.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
 
   try:
     mock_auth.login()
@@ -49,95 +49,95 @@ def test_login_success(mock_auth, auth_handler, mock_token_response):
     assert mock_auth.refresh_token_expiration > time.time()
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
 
 
 def test_login_invalid_credentials(mock_auth):
   """Test login with invalid credentials."""
 
   def handler(request):
-    return httpx.Response(401, text='Unauthorized')
+    return httpx2.Response(401, text='Unauthorized')
 
   import zdatafetch.auth
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(handler))
+    return original_client(transport=httpx2.MockTransport(handler))
 
-  zdatafetch.auth.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
 
   try:
     with pytest.raises(AuthenticationError, match='Invalid Zwift credentials'):
       mock_auth.login()
   finally:
-    zdatafetch.auth.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
 
 
 def test_login_server_error(mock_auth):
   """Test login with server error."""
 
   def handler(request):
-    return httpx.Response(500, text='Internal Server Error')
+    return httpx2.Response(500, text='Internal Server Error')
 
   import zdatafetch.auth
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(handler))
+    return original_client(transport=httpx2.MockTransport(handler))
 
-  zdatafetch.auth.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
 
   try:
     with pytest.raises(AuthenticationError, match='Authentication failed'):
       mock_auth.login()
   finally:
-    zdatafetch.auth.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
 
 
 def test_login_network_error(mock_auth):
   """Test login with network error."""
 
   def handler(request):
-    raise httpx.ConnectError('Connection failed')
+    raise httpx2.ConnectError('Connection failed')
 
   import zdatafetch.auth
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(handler))
+    return original_client(transport=httpx2.MockTransport(handler))
 
-  zdatafetch.auth.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
 
   try:
     with pytest.raises(NetworkError, match='Authentication request failed'):
       mock_auth.login()
   finally:
-    zdatafetch.auth.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
 
 
 def test_login_timeout(mock_auth):
   """Test login timeout."""
 
   def handler(request):
-    raise httpx.TimeoutException('Request timed out')
+    raise httpx2.TimeoutException('Request timed out')
 
   import zdatafetch.auth
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(handler))
+    return original_client(transport=httpx2.MockTransport(handler))
 
-  zdatafetch.auth.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
 
   try:
     with pytest.raises(NetworkError, match='Authentication request timed out'):
       mock_auth.login()
   finally:
-    zdatafetch.auth.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
 
 
 def test_get_access_token_without_login(mock_auth):
@@ -150,31 +150,31 @@ def test_get_access_token_valid(mock_auth, auth_handler, mock_token_response):
   """Test getting valid access token."""
   import zdatafetch.auth
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(auth_handler))
+    return original_client(transport=httpx2.MockTransport(auth_handler))
 
-  zdatafetch.auth.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
 
   try:
     mock_auth.login()
     token = mock_auth.get_access_token()
     assert token == mock_token_response['access_token']
   finally:
-    zdatafetch.auth.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
 
 
 def test_token_refresh(mock_auth, auth_handler, mock_token_response):
   """Test automatic token refresh."""
   import zdatafetch.auth
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(auth_handler))
+    return original_client(transport=httpx2.MockTransport(auth_handler))
 
-  zdatafetch.auth.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
 
   try:
     mock_auth.login()
@@ -188,19 +188,19 @@ def test_token_refresh(mock_auth, auth_handler, mock_token_response):
     assert mock_auth.access_token_expiration > time.time()
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
 
 
 def test_is_authenticated(mock_auth, auth_handler):
   """Test authentication status check."""
   import zdatafetch.auth
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(auth_handler))
+    return original_client(transport=httpx2.MockTransport(auth_handler))
 
-  zdatafetch.auth.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
 
   try:
     # Not authenticated initially
@@ -219,7 +219,7 @@ def test_is_authenticated(mock_auth, auth_handler):
     assert not mock_auth.is_authenticated()
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
 
 
 def test_parse_token_response(mock_auth, mock_token_response):

--- a/test/test_zdatafetch/test_cli_profile.py
+++ b/test/test_zdatafetch/test_cli_profile.py
@@ -2,7 +2,7 @@
 
 import sys
 
-import httpx
+import httpx2
 
 from zdatafetch.cli import main
 
@@ -12,10 +12,10 @@ def test_cli_single_profile_output(combined_handler, monkeypatch, capsys):
   import zdatafetch.auth
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -25,8 +25,8 @@ def test_cli_single_profile_output(combined_handler, monkeypatch, capsys):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
   monkeypatch.setattr('zdatafetch.cli.Config', MockConfig)
 
@@ -54,8 +54,8 @@ def test_cli_single_profile_output(combined_handler, monkeypatch, capsys):
     assert 'countryAlpha3:' in output
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_cli_multiple_profiles_output(combined_handler, monkeypatch, capsys):
@@ -63,10 +63,10 @@ def test_cli_multiple_profiles_output(combined_handler, monkeypatch, capsys):
   import zdatafetch.auth
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -76,8 +76,8 @@ def test_cli_multiple_profiles_output(combined_handler, monkeypatch, capsys):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
   monkeypatch.setattr('zdatafetch.cli.Config', MockConfig)
 
@@ -108,8 +108,8 @@ def test_cli_multiple_profiles_output(combined_handler, monkeypatch, capsys):
     assert output.count('ZwiftProfile(') == 2
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_cli_single_profile_raw_output(combined_handler, monkeypatch, capsys):
@@ -117,10 +117,10 @@ def test_cli_single_profile_raw_output(combined_handler, monkeypatch, capsys):
   import zdatafetch.auth
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -130,8 +130,8 @@ def test_cli_single_profile_raw_output(combined_handler, monkeypatch, capsys):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
   monkeypatch.setattr('zdatafetch.cli.Config', MockConfig)
 
@@ -153,8 +153,8 @@ def test_cli_single_profile_raw_output(combined_handler, monkeypatch, capsys):
     assert '"firstName"' in output
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_cli_multiple_profiles_raw_output(
@@ -164,10 +164,10 @@ def test_cli_multiple_profiles_raw_output(
   import zdatafetch.auth
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -177,8 +177,8 @@ def test_cli_multiple_profiles_raw_output(
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
   monkeypatch.setattr('zdatafetch.cli.Config', MockConfig)
 
@@ -202,8 +202,8 @@ def test_cli_multiple_profiles_raw_output(
     assert '"firstName"' in output
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_cli_profile_missing_credentials(monkeypatch, capsys):

--- a/test/test_zdatafetch/test_profile.py
+++ b/test/test_zdatafetch/test_profile.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from shared.exceptions import ConfigError, NetworkError
@@ -26,10 +26,10 @@ def test_fetch_single_profile(combined_handler, mock_profile_data, monkeypatch):
   import zdatafetch.config
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -39,8 +39,8 @@ def test_fetch_single_profile(combined_handler, mock_profile_data, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -59,8 +59,8 @@ def test_fetch_single_profile(combined_handler, mock_profile_data, monkeypatch):
     assert isinstance(profile._raw, str)
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_fetch_multiple_profiles(combined_handler, monkeypatch):
@@ -69,10 +69,10 @@ def test_fetch_multiple_profiles(combined_handler, monkeypatch):
   import zdatafetch.config
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -82,8 +82,8 @@ def test_fetch_multiple_profiles(combined_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -101,8 +101,8 @@ def test_fetch_multiple_profiles(combined_handler, monkeypatch):
     assert profiles[550564].id == 550564
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_fetch_profile_not_found(combined_handler, monkeypatch):
@@ -111,10 +111,10 @@ def test_fetch_profile_not_found(combined_handler, monkeypatch):
   import zdatafetch.config
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -124,8 +124,8 @@ def test_fetch_profile_not_found(combined_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -135,8 +135,8 @@ def test_fetch_profile_not_found(combined_handler, monkeypatch):
       profile.fetch(999999)
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_fetch_without_credentials(monkeypatch):
@@ -169,13 +169,13 @@ def test_fetch_network_error(auth_handler, monkeypatch):
     if 'auth/realms/zwift' in str(request.url):
       return auth_handler(request)
     if '/api/profiles/' in str(request.url):
-      raise httpx.ConnectError('Connection failed')
-    return httpx.Response(404)
+      raise httpx2.ConnectError('Connection failed')
+    return httpx2.Response(404)
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(handler))
+    return original_client(transport=httpx2.MockTransport(handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -185,8 +185,8 @@ def test_fetch_network_error(auth_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -196,8 +196,8 @@ def test_fetch_network_error(auth_handler, monkeypatch):
       profile.fetch(550564)
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_fetch_timeout(auth_handler, monkeypatch):
@@ -210,13 +210,13 @@ def test_fetch_timeout(auth_handler, monkeypatch):
     if 'auth/realms/zwift' in str(request.url):
       return auth_handler(request)
     if '/api/profiles/' in str(request.url):
-      raise httpx.TimeoutException('Request timed out')
-    return httpx.Response(404)
+      raise httpx2.TimeoutException('Request timed out')
+    return httpx2.Response(404)
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(handler))
+    return original_client(transport=httpx2.MockTransport(handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -226,8 +226,8 @@ def test_fetch_timeout(auth_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -237,8 +237,8 @@ def test_fetch_timeout(auth_handler, monkeypatch):
       profile.fetch(550564)
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_attribute_access(combined_handler, monkeypatch):
@@ -247,10 +247,10 @@ def test_attribute_access(combined_handler, monkeypatch):
   import zdatafetch.config
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -260,8 +260,8 @@ def test_attribute_access(combined_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -278,8 +278,8 @@ def test_attribute_access(combined_handler, monkeypatch):
     assert profile.countryAlpha3 == 'USA'
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_dictionary_access(combined_handler, monkeypatch):
@@ -288,10 +288,10 @@ def test_dictionary_access(combined_handler, monkeypatch):
   import zdatafetch.config
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -301,8 +301,8 @@ def test_dictionary_access(combined_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -315,8 +315,8 @@ def test_dictionary_access(combined_handler, monkeypatch):
     assert profile['ftp'] == 278
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_json_output(combined_handler, monkeypatch):
@@ -325,10 +325,10 @@ def test_json_output(combined_handler, monkeypatch):
   import zdatafetch.config
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -338,8 +338,8 @@ def test_json_output(combined_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -354,8 +354,8 @@ def test_json_output(combined_handler, monkeypatch):
     assert parsed['id'] == 550564
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_raw_output(combined_handler, monkeypatch):
@@ -364,10 +364,10 @@ def test_raw_output(combined_handler, monkeypatch):
   import zdatafetch.config
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -377,8 +377,8 @@ def test_raw_output(combined_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -393,8 +393,8 @@ def test_raw_output(combined_handler, monkeypatch):
     assert parsed['id'] == 550564
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_asdict_output(combined_handler, monkeypatch):
@@ -403,10 +403,10 @@ def test_asdict_output(combined_handler, monkeypatch):
   import zdatafetch.config
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -416,8 +416,8 @@ def test_asdict_output(combined_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -429,8 +429,8 @@ def test_asdict_output(combined_handler, monkeypatch):
     assert dict_data['id'] == 550564
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client
 
 
 def test_str_representation(combined_handler, monkeypatch):
@@ -439,10 +439,10 @@ def test_str_representation(combined_handler, monkeypatch):
   import zdatafetch.config
   import zdatafetch.profile
 
-  original_client = httpx.Client
+  original_client = httpx2.Client
 
   def mock_client(*args, **kwargs):
-    return original_client(transport=httpx.MockTransport(combined_handler))
+    return original_client(transport=httpx2.MockTransport(combined_handler))
 
   # Mock the config to return credentials
   class MockConfig:
@@ -452,8 +452,8 @@ def test_str_representation(combined_handler, monkeypatch):
     def load(self):
       pass
 
-  zdatafetch.auth.httpx.Client = mock_client
-  zdatafetch.profile.httpx.Client = mock_client
+  zdatafetch.auth.httpx2.Client = mock_client
+  zdatafetch.profile.httpx2.Client = mock_client
   monkeypatch.setattr(zdatafetch.profile, 'Config', MockConfig)
 
   try:
@@ -467,5 +467,5 @@ def test_str_representation(combined_handler, monkeypatch):
     assert 'Rider' in str_output
 
   finally:
-    zdatafetch.auth.httpx.Client = original_client
-    zdatafetch.profile.httpx.Client = original_client
+    zdatafetch.auth.httpx2.Client = original_client
+    zdatafetch.profile.httpx2.Client = original_client

--- a/test/test_zpdatafetch/conftest.py
+++ b/test/test_zpdatafetch/conftest.py
@@ -138,17 +138,17 @@ def primes_test_data():
 @pytest.fixture
 def sprints_handler(login_page, logged_in_page, sprints_test_data):
   """HTTP handler for sprints-related requests."""
-  import httpx
+  import httpx2
 
   def handler(request):
     if 'login' in str(request.url) and request.method == 'GET':
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'event_sprints' in str(request.url):
-      return httpx.Response(200, text=json.dumps(sprints_test_data))
+      return httpx2.Response(200, text=json.dumps(sprints_test_data))
     if 'event_primes' in str(request.url):
-      return httpx.Response(200, text=json.dumps({'data': []}))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps({'data': []}))
+    return httpx2.Response(404)
 
   return handler

--- a/test/test_zpdatafetch/test_async_cyclist.py
+++ b/test/test_zpdatafetch/test_async_cyclist.py
@@ -3,7 +3,7 @@
 import json
 import sys
 
-import httpx
+import httpx2
 import pytest
 
 from zpdatafetch.async_zp import AsyncZP
@@ -18,20 +18,20 @@ async def test_async_cyclist_fetch(login_page, logged_in_page):
 
   def handler(request):
     if request.method == 'GET' and 'login' in str(request.url):
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if '123456' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
 
@@ -67,22 +67,22 @@ async def test_async_multiple_fetches(login_page, logged_in_page):
 
   def handler(request):
     if request.method == 'GET' and 'login' in str(request.url):
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if '123456' in str(request.url):
-      return httpx.Response(200, text=json.dumps({'zwid': 123456}))
+      return httpx2.Response(200, text=json.dumps({'zwid': 123456}))
     if '789012' in str(request.url):
-      return httpx.Response(200, text=json.dumps({'zwid': 789012}))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps({'zwid': 789012}))
+    return httpx2.Response(404)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
 
@@ -104,20 +104,20 @@ async def test_async_data_class_json_output(login_page, logged_in_page):
 
   def handler(request):
     if request.method == 'GET' and 'login' in str(request.url):
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if '123456' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
 

--- a/test/test_zpdatafetch/test_async_league.py
+++ b/test/test_zpdatafetch/test_async_league.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from zpdatafetch.async_zp import AsyncZP
@@ -16,20 +16,20 @@ async def test_async_league_fetch(league_ok, login_page, logged_in_page):
 
   def handler(request):
     if request.method == 'GET' and 'login' in str(request.url):
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'league_standings_2780.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps(league_ok))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(league_ok))
+    return httpx2.Response(404)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
 

--- a/test/test_zpdatafetch/test_async_primes.py
+++ b/test/test_zpdatafetch/test_async_primes.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from zpdatafetch.async_zp import AsyncZP
@@ -22,20 +22,20 @@ async def test_async_primes_fetch(login_page, logged_in_page):
 
   def handler(request):
     if request.method == 'GET' and 'login' in str(request.url):
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'event_primes' in str(request.url) and '3590800' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
 

--- a/test/test_zpdatafetch/test_async_result.py
+++ b/test/test_zpdatafetch/test_async_result.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from zpdatafetch.async_zp import AsyncZP
@@ -17,20 +17,20 @@ async def test_async_result_fetch(login_page, logged_in_page):
 
   def handler(request):
     if request.method == 'GET' and 'login' in str(request.url):
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if '3590800' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
 

--- a/test/test_zpdatafetch/test_async_signup.py
+++ b/test/test_zpdatafetch/test_async_signup.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from zpdatafetch.async_zp import AsyncZP
@@ -17,20 +17,20 @@ async def test_async_signup_fetch(login_page, logged_in_page):
 
   def handler(request):
     if request.method == 'GET' and 'login' in str(request.url):
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if '3590800' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
 

--- a/test/test_zpdatafetch/test_async_sprints.py
+++ b/test/test_zpdatafetch/test_async_sprints.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
-import httpx
+import httpx2
 import pytest
 
 from zpdatafetch.async_zp import AsyncZP
@@ -21,9 +21,9 @@ async def test_async_sprints_fetch(
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(sprints_handler),
+        transport=httpx2.MockTransport(sprints_handler),
       ),
     )
 

--- a/test/test_zpdatafetch/test_async_team.py
+++ b/test/test_zpdatafetch/test_async_team.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from zpdatafetch.async_zp import AsyncZP
@@ -17,20 +17,20 @@ async def test_async_team_fetch(login_page, logged_in_page):
 
   def handler(request):
     if request.method == 'GET' and 'login' in str(request.url):
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if '123_riders.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
 

--- a/test/test_zpdatafetch/test_async_zp.py
+++ b/test/test_zpdatafetch/test_async_zp.py
@@ -1,9 +1,8 @@
 """Tests for the async ZP API."""
 
 import json
-import sys
 
-import httpx
+import httpx2
 import pytest
 
 from shared.exceptions import (
@@ -62,17 +61,17 @@ async def test_async_login_success(login_page, logged_in_page):
   def handler(request):
     match request.method:
       case 'GET':
-        return httpx.Response(200, text=login_page)
+        return httpx2.Response(200, text=login_page)
       case 'POST':
-        return httpx.Response(200, text=logged_in_page)
+        return httpx2.Response(200, text=logged_in_page)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
     await zp.login()
@@ -85,15 +84,15 @@ async def test_async_login_missing_form():
   """Test login fails when form is missing."""
 
   def handler(request):
-    return httpx.Response(200, text='<html><body>No form here</body></html>')
+    return httpx2.Response(200, text='<html><body>No form here</body></html>')
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
     with pytest.raises(AuthenticationError, match='Failed to parse login form'):
@@ -105,15 +104,15 @@ async def test_async_login_network_error():
   """Test login handles network errors."""
 
   def handler(request):
-    raise httpx.ConnectError('Connection failed')
+    raise httpx2.ConnectError('Connection failed')
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
     with pytest.raises(NetworkError, match='Failed to fetch login page'):
@@ -127,19 +126,19 @@ async def test_async_fetch_json_success():
 
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text='<html><form action="/login"></form></html>',
       )
-    return httpx.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(200, text=json.dumps(test_data))
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
     result = await zp.fetch_json('https://zwiftpower.com/api/test')
@@ -152,19 +151,19 @@ async def test_async_fetch_json_invalid_json():
 
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text='<html><form action="/login"></form></html>',
       )
-    return httpx.Response(200, text='This is not JSON')
+    return httpx2.Response(200, text='This is not JSON')
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
     result = await zp.fetch_json('https://zwiftpower.com/api/test')
@@ -178,19 +177,19 @@ async def test_async_fetch_page_success():
 
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text='<html><form action="/login"></form></html>',
       )
-    return httpx.Response(200, text=test_html)
+    return httpx2.Response(200, text=test_html)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
     result = await zp.fetch_page('https://zwiftpower.com/page/test')
@@ -205,7 +204,7 @@ async def test_async_retry_on_transient_error():
   def handler(request):
     nonlocal call_count
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text='<html><form action="/login"></form></html>',
       )
@@ -213,17 +212,17 @@ async def test_async_retry_on_transient_error():
     call_count += 1
     if call_count == 1:
       # First call fails
-      return httpx.Response(500, text='Server Error')
+      return httpx2.Response(500, text='Server Error')
     # Second call succeeds
-    return httpx.Response(200, text=json.dumps({'status': 'ok'}))
+    return httpx2.Response(200, text=json.dumps({'status': 'ok'}))
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
     result = await zp.fetch_json(
@@ -276,12 +275,6 @@ async def test_async_login_url():
     assert zp.login_url() == new_url
 
 
-@pytest.mark.xfail(
-  sys.version_info >= (3, 14),
-  reason='httpcore 1.1.x incompatible with Python 3.14 typing.Union - '
-  'upstream issue encode/httpcore, fixed in 1.2.0+',
-  strict=False,
-)
 @pytest.mark.anyio
 async def test_async_shared_client():
   """Test shared client functionality."""

--- a/test/test_zpdatafetch/test_cyclist_racelog.py
+++ b/test/test_zpdatafetch/test_cyclist_racelog.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 
 from zpdatafetch.zpcyclist import ZPCyclist
@@ -16,18 +16,18 @@ from zpdatafetch.zpracelog import ZPRacelog
 def mock_cyclist_data():
   """Mock cyclist data with race log."""
   return {
-    "data": [
+    'data': [
       {
-        "zid": "5230175",
-        "pos": 112,
-        "event_title": "Race 1",
-        "zwid": 7574336,
+        'zid': '5230175',
+        'pos': 112,
+        'event_title': 'Race 1',
+        'zwid': 7574336,
       },
       {
-        "zid": "5236642",
-        "pos": 29,
-        "event_title": "Race 2",
-        "zwid": 7574336,
+        'zid': '5236642',
+        'pos': 29,
+        'event_title': 'Race 2',
+        'zwid': 7574336,
       },
     ],
   }
@@ -35,15 +35,15 @@ def mock_cyclist_data():
 
 @pytest.fixture
 def mock_transport(mock_cyclist_data):
-  """Create a mock transport for httpx."""
+  """Create a mock transport for httpx2."""
 
-  def handler(request) -> httpx.Response:
-    return httpx.Response(
+  def handler(request) -> httpx2.Response:
+    return httpx2.Response(
       200,
       json=mock_cyclist_data,
     )
 
-  return httpx.MockTransport(handler)
+  return httpx2.MockTransport(handler)
 
 
 class TestCyclistRacelogMethod:
@@ -80,9 +80,9 @@ class TestCyclistRacelogMethod:
     cyclist._fetched[7574336] = ZPCyclist.from_dict(mock_cyclist_data)
 
     racelog = cyclist.racelog(7574336)
-    assert racelog[0].event_title == "Race 1"
+    assert racelog[0].event_title == 'Race 1'
     assert racelog[0].position == 112
-    assert racelog[1].event_title == "Race 2"
+    assert racelog[1].event_title == 'Race 2'
     assert racelog[1].position == 29
 
 
@@ -96,8 +96,8 @@ class TestCyclistRacelogErrors:
     with pytest.raises(ValueError) as exc_info:
       cyclist.racelog(123456)
 
-    assert "No data fetched" in str(exc_info.value)
-    assert "123456" in str(exc_info.value)
+    assert 'No data fetched' in str(exc_info.value)
+    assert '123456' in str(exc_info.value)
 
   def test_racelog_raises_key_error_if_missing_data_key(self):
     """Test that racelog() raises KeyError if 'data' key missing."""
@@ -107,8 +107,8 @@ class TestCyclistRacelogErrors:
     with pytest.raises(KeyError) as exc_info:
       cyclist.racelog(999)
 
-    assert "missing" in str(exc_info.value).lower()
-    assert "data" in str(exc_info.value).lower()
+    assert 'missing' in str(exc_info.value).lower()
+    assert 'data' in str(exc_info.value).lower()
 
   def test_racelog_error_message_suggests_fetch(self):
     """Test that error message suggests calling fetch()."""
@@ -117,7 +117,7 @@ class TestCyclistRacelogErrors:
     with pytest.raises(ValueError) as exc_info:
       cyclist.racelog(123456)
 
-    assert "fetch()" in str(exc_info.value) or "afetch()" in str(exc_info.value)
+    assert 'fetch()' in str(exc_info.value) or 'afetch()' in str(exc_info.value)
 
 
 class TestCyclistRacelogWithEmptyData:
@@ -126,7 +126,7 @@ class TestCyclistRacelogWithEmptyData:
   def test_racelog_with_empty_data_array(self):
     """Test racelog with empty data array."""
     cyclist = ZPCyclistFetch()
-    cyclist._fetched[123] = ZPCyclist.from_dict({"data": []})
+    cyclist._fetched[123] = ZPCyclist.from_dict({'data': []})
 
     racelog = cyclist.racelog(123)
     assert isinstance(racelog, ZPRacelog)
@@ -137,15 +137,15 @@ class TestCyclistRacelogWithEmptyData:
     cyclist = ZPCyclistFetch()
     cyclist._fetched[123] = ZPCyclist.from_dict(
       {
-        "data": [
-          {"zid": "123", "pos": 1, "event_title": "Test Race"},
+        'data': [
+          {'zid': '123', 'pos': 1, 'event_title': 'Test Race'},
         ],
       },
     )
 
     racelog = cyclist.racelog(123)
     assert len(racelog) == 1
-    assert racelog[0].event_title == "Test Race"
+    assert racelog[0].event_title == 'Test Race'
 
 
 class TestCyclistRacelogIntegration:
@@ -175,16 +175,16 @@ class TestCyclistRacelogIntegration:
     # Mock data for two different cyclists
     cyclist._fetched[111] = ZPCyclist.from_dict(
       {
-        "data": [
-          {"zid": "1", "pos": 1},
-          {"zid": "2", "pos": 2},
+        'data': [
+          {'zid': '1', 'pos': 1},
+          {'zid': '2', 'pos': 2},
         ],
       },
     )
     cyclist._fetched[222] = ZPCyclist.from_dict(
       {
-        "data": [
-          {"zid": "3", "pos": 3},
+        'data': [
+          {'zid': '3', 'pos': 3},
         ],
       },
     )
@@ -202,9 +202,11 @@ class TestCyclistRacelogWithRealFixture:
   @pytest.fixture
   def real_cyclist_data(self):
     """Load real cyclist data from fixture."""
-    fixture_path = Path(__file__).parent.parent.parent / "tmp" / "7574336_all.json"
+    fixture_path = (
+      Path(__file__).parent.parent.parent / 'tmp' / '7574336_all.json'
+    )
     if not fixture_path.exists():
-      pytest.skip("Fixture file not available")
+      pytest.skip('Fixture file not available')
 
     with open(fixture_path) as f:
       return json.load(f)
@@ -222,7 +224,7 @@ class TestCyclistRacelogWithRealFixture:
     # Test that we can iterate
     for race in racelog:
       assert isinstance(race, ZPRaceFinish)
-      assert hasattr(race, "event_title")
+      assert hasattr(race, 'event_title')
 
   def test_racelog_serialization_with_real_data(self, real_cyclist_data):
     """Test that racelog from real data can be serialized."""
@@ -259,9 +261,11 @@ class TestCyclistRacelogWithRealFixture:
 
   def test_large_racelog(self):
     """Test with large racelog (550564_all.json)."""
-    fixture_path = Path(__file__).parent.parent.parent / "tmp" / "550564_all.json"
+    fixture_path = (
+      Path(__file__).parent.parent.parent / 'tmp' / '550564_all.json'
+    )
     if not fixture_path.exists():
-      pytest.skip("Large fixture file not available")
+      pytest.skip('Large fixture file not available')
 
     with open(fixture_path) as f:
       data = json.load(f)

--- a/test/test_zpdatafetch/test_zp.py
+++ b/test/test_zpdatafetch/test_zp.py
@@ -1,7 +1,6 @@
 import json
-import sys
 
-import httpx
+import httpx2
 import pytest
 
 from shared.exceptions import AuthenticationError, NetworkError
@@ -16,12 +15,14 @@ def test_fetch_login_page(
   def handler(request):
     match request.method:
       case 'GET':
-        return httpx.Response(200, text=login_page)
+        return httpx2.Response(200, text=login_page)
       case 'POST':
-        return httpx.Response(200, text=logged_in_page)
+        return httpx2.Response(200, text=logged_in_page)
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
   zp.login()
   assert zp.login_response.status_code == 200
@@ -29,10 +30,12 @@ def test_fetch_login_page(
 
 def test_login_network_error_on_get(zp, login_page):
   def handler(request):
-    raise httpx.ConnectError('Connection failed')
+    raise httpx2.ConnectError('Connection failed')
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
 
   with pytest.raises(NetworkError, match='Failed to fetch login page'):
@@ -41,10 +44,12 @@ def test_login_network_error_on_get(zp, login_page):
 
 def test_login_http_error_on_get(zp):
   def handler(request):
-    return httpx.Response(500, text='Server Error')
+    return httpx2.Response(500, text='Server Error')
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
 
   with pytest.raises(NetworkError, match='Failed to fetch login page'):
@@ -53,10 +58,12 @@ def test_login_http_error_on_get(zp):
 
 def test_login_missing_form(zp):
   def handler(request):
-    return httpx.Response(200, text='<html><body>No form here</body></html>')
+    return httpx2.Response(200, text='<html><body>No form here</body></html>')
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
 
   with pytest.raises(AuthenticationError, match='Failed to parse login form'):
@@ -69,10 +76,10 @@ def test_login_failed_authentication(zp, login_page):
   # Creating a proper redirect mock in httpx is complex, so we test the logic
 
   # Create a mock response that looks like a failed login redirect
-  mock_response = httpx.Response(
+  mock_response = httpx2.Response(
     200,
     text=login_page,
-    request=httpx.Request('POST', 'https://zwiftpower.com/ucp.php?mode=login'),
+    request=httpx2.Request('POST', 'https://zwiftpower.com/ucp.php?mode=login'),
   )
 
   # Verify our detection logic would catch this
@@ -87,13 +94,15 @@ def test_fetch_json_success(zp):
 
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200, text='<html><form action="/login"></form></html>'
       )
-    return httpx.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(200, text=json.dumps(test_data))
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
 
   result = zp.fetch_json('https://zwiftpower.com/api/test')
@@ -103,13 +112,15 @@ def test_fetch_json_success(zp):
 def test_fetch_json_invalid_json(zp):
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200, text='<html><form action="/login"></form></html>'
       )
-    return httpx.Response(200, text='not valid json')
+    return httpx2.Response(200, text='not valid json')
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
 
   result = zp.fetch_json('https://zwiftpower.com/api/test')
@@ -119,13 +130,15 @@ def test_fetch_json_invalid_json(zp):
 def test_fetch_json_network_error(zp):
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200, text='<html><form action="/login"></form></html>'
       )
-    raise httpx.ConnectError('Network error')
+    raise httpx2.ConnectError('Network error')
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
 
   with pytest.raises(NetworkError, match='Failed after'):
@@ -137,13 +150,15 @@ def test_fetch_page_success(zp):
 
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200, text='<html><form action="/login"></form></html>'
       )
-    return httpx.Response(200, text=test_html)
+    return httpx2.Response(200, text=test_html)
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
 
   result = zp.fetch_page('https://zwiftpower.com/profile.php?z=123')
@@ -153,13 +168,15 @@ def test_fetch_page_success(zp):
 def test_fetch_page_http_error(zp):
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200, text='<html><form action="/login"></form></html>'
       )
-    return httpx.Response(404, text='Not Found')
+    return httpx2.Response(404, text='Not Found')
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
 
   with pytest.raises(NetworkError, match='Failed to fetch page'):
@@ -199,15 +216,15 @@ def test_context_manager(zp):
 
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text='<html><form action="https://zwiftpower.com/login"></form></html>',
       )
-    return httpx.Response(200, text=json.dumps({'data': 'test'}))
+    return httpx2.Response(200, text=json.dumps({'data': 'test'}))
 
-  client = httpx.Client(
+  client = httpx2.Client(
     follow_redirects=True,
-    transport=httpx.MockTransport(handler),
+    transport=httpx2.MockTransport(handler),
   )
 
   with ZP(skip_credential_check=True) as zp_ctx:
@@ -226,26 +243,26 @@ def test_context_manager_with_exception(zp):
 
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text='<html><form action="https://zwiftpower.com/login"></form></html>',
       )
-    raise httpx.ConnectError('Forced error')
+    raise httpx2.ConnectError('Forced error')
 
   with ZP(skip_credential_check=True) as zp_ctx:
 
     def mock_handler(request):
       if 'login' in str(request.url):
-        return httpx.Response(
+        return httpx2.Response(
           200,
           text='<html><form action="https://zwiftpower.com/login"></form></html>',
         )
-      raise httpx.ConnectError('Forced error')
+      raise httpx2.ConnectError('Forced error')
 
     zp_ctx.init_client(
-      httpx.Client(
+      httpx2.Client(
         follow_redirects=True,
-        transport=httpx.MockTransport(mock_handler),
+        transport=httpx2.MockTransport(mock_handler),
       ),
     )
     zp_ctx.login()
@@ -258,26 +275,20 @@ def test_context_manager_with_exception(zp):
   assert isinstance(zp_ctx, ZP)
 
 
-@pytest.mark.xfail(
-  sys.version_info >= (3, 14),
-  reason='httpcore 1.1.x incompatible with Python 3.14 typing.Union - '
-  'upstream issue encode/httpcore, fixed in 1.2.0+',
-  strict=False,
-)
 def test_shared_client_connection_pooling():
   """Test shared client enables connection pooling."""
 
   def handler(request):
     if 'login' in str(request.url):
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text='<html><form action="https://zwiftpower.com/login"></form></html>',
       )
-    return httpx.Response(200, json={'id': request.url.params.get('id', '?')})
+    return httpx2.Response(200, json={'id': request.url.params.get('id', '?')})
 
-  client = httpx.Client(
+  client = httpx2.Client(
     follow_redirects=True,
-    transport=httpx.MockTransport(handler),
+    transport=httpx2.MockTransport(handler),
   )
 
   try:
@@ -305,10 +316,12 @@ def test_fetch_with_retry_success(zp):
   """Test _fetch_with_retry succeeds on first attempt."""
 
   def handler(request):
-    return httpx.Response(200, json={'data': 'success'})
+    return httpx2.Response(200, json={'data': 'success'})
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
   response = zp._fetch_with_retry(
     'https://zwiftpower.com/api/test', max_retries=3
@@ -324,11 +337,13 @@ def test_fetch_with_retry_transient_error(zp):
     nonlocal attempt_count
     attempt_count += 1
     if attempt_count < 3:
-      raise httpx.ConnectError('Transient error')
-    return httpx.Response(200, json={'data': 'success'})
+      raise httpx2.ConnectError('Transient error')
+    return httpx2.Response(200, json={'data': 'success'})
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
   response = zp._fetch_with_retry(
     'https://zwiftpower.com/api/test',
@@ -343,10 +358,12 @@ def test_fetch_with_retry_max_retries_exceeded(zp):
   """Test _fetch_with_retry fails after max retries."""
 
   def handler(request):
-    raise httpx.ConnectError('Persistent error')
+    raise httpx2.ConnectError('Persistent error')
 
   zp.init_client(
-    httpx.Client(follow_redirects=True, transport=httpx.MockTransport(handler)),
+    httpx2.Client(
+      follow_redirects=True, transport=httpx2.MockTransport(handler)
+    ),
   )
 
   with pytest.raises(NetworkError, match='Failed after 3 attempts'):

--- a/test/test_zpdatafetch/test_zpcyclistfetch.py
+++ b/test/test_zpdatafetch/test_zpcyclistfetch.py
@@ -1,6 +1,6 @@
 import json
 
-import httpx
+import httpx2
 
 from zpdatafetch.zpcyclist import ZPCyclist
 
@@ -37,12 +37,12 @@ def test_cyclist_sync_mode_fetch(cyclist, login_page, logged_in_page):
 
   def handler(request):
     if 'login' in str(request.url) and request.method == 'GET':
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'profile' in str(request.url) and '_all.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   # Enable sync mode
   ZPCyclistFetch.set_sync_mode(True)
@@ -52,9 +52,9 @@ def test_cyclist_sync_mode_fetch(cyclist, login_page, logged_in_page):
 
   def mock_init(self, skip_credential_check=False, shared_client=False):
     original_init(self, skip_credential_check=True, shared_client=False)
-    self._client = httpx.Client(
+    self._client = httpx2.Client(
       follow_redirects=True,
-      transport=httpx.MockTransport(handler),
+      transport=httpx2.MockTransport(handler),
     )
 
   ZP.__init__ = mock_init
@@ -101,12 +101,12 @@ def test_cyclist_fetch_single_id(cyclist, login_page, logged_in_page):
 
   def handler(request):
     if 'login' in str(request.url) and request.method == 'GET':
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'profile' in str(request.url) and '_all.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   from zpdatafetch.async_zp import AsyncZP
 
@@ -115,9 +115,9 @@ def test_cyclist_fetch_single_id(cyclist, login_page, logged_in_page):
 
   def mock_init(self, skip_credential_check=False):
     original_init(self, skip_credential_check=True)
-    self._client = httpx.AsyncClient(
+    self._client = httpx2.AsyncClient(
       follow_redirects=True,
-      transport=httpx.MockTransport(handler),
+      transport=httpx2.MockTransport(handler),
     )
 
   AsyncZP.__init__ = mock_init
@@ -151,14 +151,14 @@ def test_cyclist_fetch_single_id(cyclist, login_page, logged_in_page):
 def test_cyclist_fetch_multiple_ids(cyclist, login_page, logged_in_page):
   def handler(request):
     if 'login' in str(request.url) and request.method == 'GET':
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if '123456' in str(request.url) and '_all.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps({'id': 123456}))
+      return httpx2.Response(200, text=json.dumps({'id': 123456}))
     if '789012' in str(request.url) and '_all.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps({'id': 789012}))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps({'id': 789012}))
+    return httpx2.Response(404)
 
   from zpdatafetch.async_zp import AsyncZP
 
@@ -166,9 +166,9 @@ def test_cyclist_fetch_multiple_ids(cyclist, login_page, logged_in_page):
 
   def mock_init(self, skip_credential_check=False):
     original_init(self, skip_credential_check=True)
-    self._client = httpx.AsyncClient(
+    self._client = httpx2.AsyncClient(
       follow_redirects=True,
-      transport=httpx.MockTransport(handler),
+      transport=httpx2.MockTransport(handler),
     )
 
   AsyncZP.__init__ = mock_init

--- a/test/test_zpdatafetch/test_zpleaguefetch.py
+++ b/test/test_zpdatafetch/test_zpleaguefetch.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from shared.validation import ValidationError
@@ -36,20 +36,20 @@ def test_league_init():
 def test_league_fetch_single_id(league, league_ok, login_page, logged_in_page):
   def handler(request):
     if 'login' in str(request.url) and request.method == 'GET':
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'league_standings' in str(request.url) and '.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps(league_ok))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(league_ok))
+    return httpx2.Response(404)
 
   original_init = AsyncZP.__init__
 
   def mock_init(self, skip_credential_check=False):
     original_init(self, skip_credential_check=True)
-    self._client = httpx.AsyncClient(
+    self._client = httpx2.AsyncClient(
       follow_redirects=True,
-      transport=httpx.MockTransport(handler),
+      transport=httpx2.MockTransport(handler),
     )
 
   AsyncZP.__init__ = mock_init
@@ -83,20 +83,20 @@ async def test_league_afetch(league_ok, login_page, logged_in_page):
 
   def handler(request):
     if request.method == 'GET' and 'login' in str(request.url):
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'league_standings_2780.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps(league_ok))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(league_ok))
+    return httpx2.Response(404)
 
   async with AsyncZP(skip_credential_check=True) as zp:
     zp.username = 'testuser'
     zp.password = 'testpass'
     await zp.init_client(
-      httpx.AsyncClient(
+      httpx2.AsyncClient(
         follow_redirects=True,
-        transport=httpx.MockTransport(handler),
+        transport=httpx2.MockTransport(handler),
       ),
     )
 

--- a/test/test_zpdatafetch/test_zpprimesfetch.py
+++ b/test/test_zpdatafetch/test_zpprimesfetch.py
@@ -1,6 +1,6 @@
 import json
 
-import httpx
+import httpx2
 
 from zpdatafetch import ZPPrimesFetch
 from zpdatafetch.zpprime import ZPPrime, ZPPrimeResult, ZPPrimeSegment
@@ -75,12 +75,12 @@ def test_primes_fetch(primes, login_page, logged_in_page):
 
   def handler(request):
     if 'login' in str(request.url) and request.method == 'GET':
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'event_primes' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   from zpdatafetch.async_zp import AsyncZP
 
@@ -88,9 +88,9 @@ def test_primes_fetch(primes, login_page, logged_in_page):
 
   def mock_init(self, skip_credential_check=False):
     original_init(self, skip_credential_check=True)
-    self._client = httpx.AsyncClient(
+    self._client = httpx2.AsyncClient(
       follow_redirects=True,
-      transport=httpx.MockTransport(handler),
+      transport=httpx2.MockTransport(handler),
     )
 
   AsyncZP.__init__ = mock_init

--- a/test/test_zpdatafetch/test_zpresultfetch.py
+++ b/test/test_zpdatafetch/test_zpresultfetch.py
@@ -1,6 +1,6 @@
 import json
 
-import httpx
+import httpx2
 
 from zpdatafetch.zpraceresult import ZPRaceResult, ZPRiderFinish
 
@@ -42,12 +42,12 @@ def test_result_fetch_race_results(result, login_page, logged_in_page):
 
   def handler(request):
     if 'login' in str(request.url) and request.method == 'GET':
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'results' in str(request.url) and '_view.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   from zpdatafetch.async_zp import AsyncZP
 
@@ -55,9 +55,9 @@ def test_result_fetch_race_results(result, login_page, logged_in_page):
 
   def mock_init(self, skip_credential_check=False):
     original_init(self, skip_credential_check=True)
-    self._client = httpx.AsyncClient(
+    self._client = httpx2.AsyncClient(
       follow_redirects=True,
-      transport=httpx.MockTransport(handler),
+      transport=httpx2.MockTransport(handler),
     )
 
   AsyncZP.__init__ = mock_init

--- a/test/test_zpdatafetch/test_zpsignupfetch.py
+++ b/test/test_zpdatafetch/test_zpsignupfetch.py
@@ -1,6 +1,6 @@
 import json
 
-import httpx
+import httpx2
 
 from zpdatafetch.zpracesignup import ZPRaceSignup, ZPRiderSignup
 
@@ -40,12 +40,12 @@ def test_signup_fetch_race_signups(signup, login_page, logged_in_page):
 
   def handler(request):
     if 'login' in str(request.url) and request.method == 'GET':
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'results' in str(request.url) and '_signups.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   from zpdatafetch.async_zp import AsyncZP
 
@@ -53,9 +53,9 @@ def test_signup_fetch_race_signups(signup, login_page, logged_in_page):
 
   def mock_init(self, skip_credential_check=False):
     original_init(self, skip_credential_check=True)
-    self._client = httpx.AsyncClient(
+    self._client = httpx2.AsyncClient(
       follow_redirects=True,
-      transport=httpx.MockTransport(handler),
+      transport=httpx2.MockTransport(handler),
     )
 
   AsyncZP.__init__ = mock_init

--- a/test/test_zpdatafetch/test_zpsprintsfetch.py
+++ b/test/test_zpdatafetch/test_zpsprintsfetch.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-import httpx
+import httpx2
 
 from zpdatafetch.zpracesprint import ZPRaceSprint, ZPRiderSprint
 
@@ -43,9 +43,9 @@ def test_sprints_fetch_race_sprints(
 
   def mock_init(self, skip_credential_check=False):
     original_init(self, skip_credential_check=True)
-    self._client = httpx.AsyncClient(
+    self._client = httpx2.AsyncClient(
       follow_redirects=True,
-      transport=httpx.MockTransport(sprints_handler),
+      transport=httpx2.MockTransport(sprints_handler),
     )
 
   AsyncZP.__init__ = mock_init
@@ -85,9 +85,9 @@ def test_sprints_shares_zp_session_with_primes(
   def mock_init(self, skip_credential_check=False):
     original_init(self, skip_credential_check=True)
     login_count['count'] += 1  # Track how many AsyncZP instances are created
-    self._client = httpx.AsyncClient(
+    self._client = httpx2.AsyncClient(
       follow_redirects=True,
-      transport=httpx.MockTransport(sprints_handler),
+      transport=httpx2.MockTransport(sprints_handler),
     )
 
   AsyncZP.__init__ = mock_init

--- a/test/test_zpdatafetch/test_zpteamfetch.py
+++ b/test/test_zpdatafetch/test_zpteamfetch.py
@@ -1,6 +1,6 @@
 import json
 
-import httpx
+import httpx2
 
 from zpdatafetch.zpteam import ZPTeam, ZPTeamMember
 
@@ -49,12 +49,12 @@ def test_team_fetch_single_id(team, login_page, logged_in_page):
 
   def handler(request):
     if 'login' in str(request.url) and request.method == 'GET':
-      return httpx.Response(200, text=login_page)
+      return httpx2.Response(200, text=login_page)
     if request.method == 'POST':
-      return httpx.Response(200, text=logged_in_page)
+      return httpx2.Response(200, text=logged_in_page)
     if 'teams' in str(request.url) and '.json' in str(request.url):
-      return httpx.Response(200, text=json.dumps(test_data))
-    return httpx.Response(404)
+      return httpx2.Response(200, text=json.dumps(test_data))
+    return httpx2.Response(404)
 
   from zpdatafetch.async_zp import AsyncZP
 
@@ -62,9 +62,9 @@ def test_team_fetch_single_id(team, login_page, logged_in_page):
 
   def mock_init(self, skip_credential_check=False):
     original_init(self, skip_credential_check=True)
-    self._client = httpx.AsyncClient(
+    self._client = httpx2.AsyncClient(
       follow_redirects=True,
-      transport=httpx.MockTransport(handler),
+      transport=httpx2.MockTransport(handler),
     )
 
   AsyncZP.__init__ = mock_init

--- a/test/test_zrdatafetch/test_async_zr.py
+++ b/test/test_zrdatafetch/test_async_zr.py
@@ -34,7 +34,7 @@ class TestAsyncZRObjInitialization:
   async def test_init_shared_client_true(self):
     """Test initialization with shared_client=True."""
     # Mock AsyncClient to prevent real connections
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 
@@ -57,7 +57,7 @@ class TestAsyncZRObjContextManager:
   @pytest.mark.anyio
   async def test_context_manager_aexit(self):
     """Test __aexit__ properly cleans up."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 
@@ -70,7 +70,7 @@ class TestAsyncZRObjContextManager:
   @pytest.mark.anyio
   async def test_context_manager_cleanup(self):
     """Test context manager properly closes client."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 
@@ -88,7 +88,7 @@ class TestAsyncZRObjClientInitialization:
   @pytest.mark.anyio
   async def test_init_client_creates_new(self):
     """Test init_client creates a new client."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 
@@ -109,7 +109,7 @@ class TestAsyncZRObjClientInitialization:
   @pytest.mark.anyio
   async def test_init_client_uses_shared(self):
     """Test init_client uses shared client when available."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 
@@ -134,7 +134,7 @@ class TestAsyncZRObjFetchJson:
   @pytest.mark.anyio
   async def test_fetch_json_initializes_client(self):
     """Test fetch_json initializes client if needed."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_response = MagicMock()
       mock_response.text = '{"test": "data"}'
@@ -153,7 +153,7 @@ class TestAsyncZRObjFetchJson:
   @pytest.mark.anyio
   async def test_fetch_json_returns_string(self):
     """Test fetch_json returns raw JSON string."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_response = MagicMock()
       mock_response.text = '{"id": 12345, "name": "Test Rider"}'
@@ -169,7 +169,7 @@ class TestAsyncZRObjFetchJson:
   @pytest.mark.anyio
   async def test_fetch_json_with_method_post(self):
     """Test fetch_json supports POST method."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_response = MagicMock()
       mock_response.text = '[{"id": 12345}, {"id": 67890}]'
@@ -193,7 +193,7 @@ class TestAsyncZRObjFetchJson:
   @pytest.mark.anyio
   async def test_fetch_json_with_headers(self):
     """Test fetch_json accepts headers."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_response = MagicMock()
       mock_response.text = '{"id": 12345}'
@@ -219,7 +219,7 @@ class TestAsyncZRObjClose:
   @pytest.mark.anyio
   async def test_close_owned_client(self):
     """Test close properly closes owned client."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 
@@ -234,7 +234,7 @@ class TestAsyncZRObjClose:
   @pytest.mark.anyio
   async def test_close_shared_client(self):
     """Test close doesn't close shared client."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 
@@ -255,7 +255,7 @@ class TestAsyncZRObjClose:
   @pytest.mark.anyio
   async def test_close_idempotent(self):
     """Test close can be called multiple times safely."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 
@@ -276,7 +276,7 @@ class TestAsyncZRObjSharedSession:
   @pytest.mark.anyio
   async def test_close_shared_session_clears_reference(self):
     """Test close_shared_session clears the shared client."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 
@@ -297,7 +297,7 @@ class TestAsyncZRObjSharedSession:
   @pytest.mark.anyio
   async def test_multiple_instances_share_client(self):
     """Test multiple instances with shared_client=True share the same client."""
-    with patch('httpx.AsyncClient') as mock_client_class:
+    with patch('httpx2.AsyncClient') as mock_client_class:
       mock_client = AsyncMock()
       mock_client_class.return_value = mock_client
 

--- a/test/test_zrdatafetch/test_zr_obj.py
+++ b/test/test_zrdatafetch/test_zr_obj.py
@@ -7,7 +7,7 @@ HTTP client management, error handling, and JSON serialization.
 import json
 from unittest.mock import MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 
 from shared.exceptions import NetworkError
@@ -19,12 +19,12 @@ class TestZR_objClientManagement:
   """Test HTTP client management and pooling."""
 
   def test_get_client_creates_client(self):
-    """Test that get_client creates an httpx.Client instance."""
+    """Test that get_client creates an httpx2.Client instance."""
     # Clean up any existing client
     ZR_obj._client = None
 
-    # Mock httpx.Client to prevent real connections
-    with patch('httpx.Client') as mock_client_class:
+    # Mock httpx2.Client to prevent real connections
+    with patch('httpx2.Client') as mock_client_class:
       mock_client = MagicMock()
       mock_client.base_url = 'https://api.zwiftracing.app/api'
       mock_client_class.return_value = mock_client
@@ -39,7 +39,7 @@ class TestZR_objClientManagement:
     # Clean up and create a fresh client
     ZR_obj._client = None
 
-    with patch('httpx.Client') as mock_client_class:
+    with patch('httpx2.Client') as mock_client_class:
       mock_client = MagicMock()
       mock_client_class.return_value = mock_client
 
@@ -54,7 +54,7 @@ class TestZR_objClientManagement:
     """Test that close_client properly closes the connection."""
     ZR_obj._client = None
 
-    with patch('httpx.Client') as mock_client_class:
+    with patch('httpx2.Client') as mock_client_class:
       mock_client = MagicMock()
       mock_client_class.return_value = mock_client
 
@@ -102,7 +102,7 @@ class TestZR_objFetchJson:
     response = MagicMock()
     response.status_code = 404
     response.reason_phrase = 'Not Found'
-    http_error = httpx.HTTPStatusError(
+    http_error = httpx2.HTTPStatusError(
       '404 Not Found', request=None, response=response
     )
 
@@ -119,7 +119,7 @@ class TestZR_objFetchJson:
     obj = ZR_obj()
 
     # Create a mock network error
-    network_error = httpx.RequestError('Connection failed')
+    network_error = httpx2.RequestError('Connection failed')
 
     with patch.object(ZR_obj, 'get_client') as mock_get_client:
       mock_client = MagicMock()
@@ -189,7 +189,7 @@ class TestZR_objIntegration:
     """Test that multiple instances share the same HTTP client."""
     ZR_obj._client = None
 
-    with patch('httpx.Client') as mock_client_class:
+    with patch('httpx2.Client') as mock_client_class:
       mock_client = MagicMock()
       mock_client_class.return_value = mock_client
 
@@ -207,7 +207,7 @@ class TestZR_objIntegration:
     """Test complete client lifecycle."""
     ZR_obj._client = None
 
-    with patch('httpx.Client') as mock_client_class:
+    with patch('httpx2.Client') as mock_client_class:
       mock_client1 = MagicMock()
       mock_client3 = MagicMock()
       mock_client_class.side_effect = [mock_client1, mock_client3]

--- a/test/test_zsdatafetch/cli/test_cli_zs.py
+++ b/test/test_zsdatafetch/cli/test_cli_zs.py
@@ -4,7 +4,7 @@ import json
 import logging
 from unittest.mock import patch
 
-import httpx
+import httpx2
 
 from zsdatafetch.cli import main
 from zsdatafetch.zs import ZS_obj
@@ -68,7 +68,8 @@ class TestCLI:
 
   def test_incidents_noaction(self, capsys):
     with patch(
-      'sys.argv', ['zsdata', 'incidents', '--noaction'],
+      'sys.argv',
+      ['zsdata', 'incidents', '--noaction'],
     ):
       result = main()
     assert result is None
@@ -87,7 +88,8 @@ class TestCLI:
 
   def test_maintenance_noaction(self, capsys):
     with patch(
-      'sys.argv', ['zsdata', 'maintenance', '--noaction'],
+      'sys.argv',
+      ['zsdata', 'maintenance', '--noaction'],
     ):
       result = main()
     assert result is None
@@ -118,12 +120,14 @@ class TestCLI:
 
   def test_status_command(self, summary_json, capsys):
     def handler(request):
-      return httpx.Response(
-        200, text=summary_json, request=request,
+      return httpx2.Response(
+        200,
+        text=summary_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     with patch('sys.argv', ['zsdata', 'status', '--sync']):
       result = main()
@@ -133,15 +137,18 @@ class TestCLI:
 
   def test_status_raw(self, summary_json, capsys):
     def handler(request):
-      return httpx.Response(
-        200, text=summary_json, request=request,
+      return httpx2.Response(
+        200,
+        text=summary_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     with patch(
-      'sys.argv', ['zsdata', 'status', '--raw', '--sync'],
+      'sys.argv',
+      ['zsdata', 'status', '--raw', '--sync'],
     ):
       result = main()
     assert result is None
@@ -151,15 +158,18 @@ class TestCLI:
 
   def test_status_json(self, summary_json, capsys):
     def handler(request):
-      return httpx.Response(
-        200, text=summary_json, request=request,
+      return httpx2.Response(
+        200,
+        text=summary_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     with patch(
-      'sys.argv', ['zsdata', 'status', '--json', '--sync'],
+      'sys.argv',
+      ['zsdata', 'status', '--json', '--sync'],
     ):
       result = main()
     assert result is None
@@ -169,32 +179,40 @@ class TestCLI:
 
   def test_incidents_command(self, incidents_json, capsys):
     def handler(request):
-      return httpx.Response(
-        200, text=incidents_json, request=request,
+      return httpx2.Response(
+        200,
+        text=incidents_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     with patch(
-      'sys.argv', ['zsdata', 'incidents', '--sync'],
+      'sys.argv',
+      ['zsdata', 'incidents', '--sync'],
     ):
       result = main()
     assert result is None
 
   def test_maintenance_command(
-    self, maintenance_json, capsys,
+    self,
+    maintenance_json,
+    capsys,
   ):
     def handler(request):
-      return httpx.Response(
-        200, text=maintenance_json, request=request,
+      return httpx2.Response(
+        200,
+        text=maintenance_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     with patch(
-      'sys.argv', ['zsdata', 'maintenance', '--sync'],
+      'sys.argv',
+      ['zsdata', 'maintenance', '--sync'],
     ):
       result = main()
     assert result is None

--- a/test/test_zsdatafetch/test_incident_fetch.py
+++ b/test/test_zsdatafetch/test_incident_fetch.py
@@ -1,6 +1,6 @@
 """Tests for ZSIncidentFetch."""
 
-import httpx
+import httpx2
 import pytest
 
 from zsdatafetch.models.incident import ZSIncident
@@ -23,12 +23,14 @@ class TestZSIncidentFetch:
     def handler(request):
       assert '/incidents.json' in str(request.url)
       assert 'unresolved' not in str(request.url)
-      return httpx.Response(
-        200, text=incidents_json, request=request,
+      return httpx2.Response(
+        200,
+        text=incidents_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSIncidentFetch()
     result = fetcher.fetch()
@@ -39,14 +41,14 @@ class TestZSIncidentFetch:
   def test_fetch_unresolved(self, incidents_unresolved_json):
     def handler(request):
       assert '/incidents/unresolved.json' in str(request.url)
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text=incidents_unresolved_json,
         request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSIncidentFetch()
     result = fetcher.fetch(unresolved_only=True)
@@ -54,15 +56,18 @@ class TestZSIncidentFetch:
 
   def test_empty_incidents(self):
     import json
+
     empty = json.dumps({'page': {}, 'incidents': []})
 
     def handler(request):
-      return httpx.Response(
-        200, text=empty, request=request,
+      return httpx2.Response(
+        200,
+        text=empty,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSIncidentFetch()
     result = fetcher.fetch()
@@ -70,12 +75,14 @@ class TestZSIncidentFetch:
 
   def test_raw(self, incidents_json):
     def handler(request):
-      return httpx.Response(
-        200, text=incidents_json, request=request,
+      return httpx2.Response(
+        200,
+        text=incidents_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSIncidentFetch()
     fetcher.fetch()
@@ -83,12 +90,14 @@ class TestZSIncidentFetch:
 
   def test_fetched(self, incidents_json):
     def handler(request):
-      return httpx.Response(
-        200, text=incidents_json, request=request,
+      return httpx2.Response(
+        200,
+        text=incidents_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSIncidentFetch()
     assert fetcher.fetched() == []
@@ -98,14 +107,17 @@ class TestZSIncidentFetch:
   @pytest.mark.anyio
   async def test_afetch_incidents(self, incidents_json):
     async def handler(request):
-      return httpx.Response(
-        200, text=incidents_json, request=request,
+      return httpx2.Response(
+        200,
+        text=incidents_json,
+        request=request,
       )
 
     from zsdatafetch.async_zs import AsyncZS_obj
+
     zs = AsyncZS_obj()
-    zs._client = httpx.AsyncClient(
-      transport=httpx.MockTransport(handler),
+    zs._client = httpx2.AsyncClient(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSIncidentFetch()
     fetcher.set_session(zs)

--- a/test/test_zsdatafetch/test_maintenance_fetch.py
+++ b/test/test_zsdatafetch/test_maintenance_fetch.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from zsdatafetch.zs import ZS_obj
@@ -26,12 +26,14 @@ class TestZSMaintenanceFetch:
       assert '/scheduled-maintenances.json' in url
       assert 'upcoming' not in url
       assert 'active' not in url
-      return httpx.Response(
-        200, text=maintenance_json, request=request,
+      return httpx2.Response(
+        200,
+        text=maintenance_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSMaintenanceFetch()
     result = fetcher.fetch()
@@ -40,14 +42,14 @@ class TestZSMaintenanceFetch:
   def test_fetch_upcoming(self, maintenance_upcoming_json):
     def handler(request):
       assert 'upcoming.json' in str(request.url)
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text=maintenance_upcoming_json,
         request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSMaintenanceFetch()
     result = fetcher.fetch(upcoming=True)
@@ -56,14 +58,14 @@ class TestZSMaintenanceFetch:
   def test_fetch_active(self, maintenance_active_json):
     def handler(request):
       assert 'active.json' in str(request.url)
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text=maintenance_active_json,
         request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSMaintenanceFetch()
     result = fetcher.fetch(active=True)
@@ -75,12 +77,14 @@ class TestZSMaintenanceFetch:
     )
 
     def handler(request):
-      return httpx.Response(
-        200, text=empty, request=request,
+      return httpx2.Response(
+        200,
+        text=empty,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSMaintenanceFetch()
     result = fetcher.fetch()
@@ -88,12 +92,14 @@ class TestZSMaintenanceFetch:
 
   def test_raw(self, maintenance_json):
     def handler(request):
-      return httpx.Response(
-        200, text=maintenance_json, request=request,
+      return httpx2.Response(
+        200,
+        text=maintenance_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSMaintenanceFetch()
     fetcher.fetch()
@@ -112,17 +118,21 @@ class TestZSMaintenanceFetch:
 
   @pytest.mark.anyio
   async def test_afetch_maintenance(
-    self, maintenance_json,
+    self,
+    maintenance_json,
   ):
     async def handler(request):
-      return httpx.Response(
-        200, text=maintenance_json, request=request,
+      return httpx2.Response(
+        200,
+        text=maintenance_json,
+        request=request,
       )
 
     from zsdatafetch.async_zs import AsyncZS_obj
+
     zs = AsyncZS_obj()
-    zs._client = httpx.AsyncClient(
-      transport=httpx.MockTransport(handler),
+    zs._client = httpx2.AsyncClient(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSMaintenanceFetch()
     fetcher.set_session(zs)

--- a/test/test_zsdatafetch/test_summary_fetch.py
+++ b/test/test_zsdatafetch/test_summary_fetch.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from zsdatafetch.models.summary import ZSSummary
@@ -24,12 +24,14 @@ class TestZSSummaryFetch:
   def test_fetch_summary(self, summary_json):
     def handler(request):
       assert '/summary.json' in str(request.url)
-      return httpx.Response(
-        200, text=summary_json, request=request,
+      return httpx2.Response(
+        200,
+        text=summary_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSSummaryFetch()
     result = fetcher.fetch()
@@ -41,12 +43,14 @@ class TestZSSummaryFetch:
   def test_fetch_components_only(self, components_json):
     def handler(request):
       assert '/components.json' in str(request.url)
-      return httpx.Response(
-        200, text=components_json, request=request,
+      return httpx2.Response(
+        200,
+        text=components_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSSummaryFetch()
     result = fetcher.fetch(components_only=True)
@@ -55,12 +59,14 @@ class TestZSSummaryFetch:
 
   def test_fetch_raw(self, summary_json):
     def handler(request):
-      return httpx.Response(
-        200, text=summary_json, request=request,
+      return httpx2.Response(
+        200,
+        text=summary_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSSummaryFetch()
     fetcher.fetch()
@@ -69,12 +75,14 @@ class TestZSSummaryFetch:
 
   def test_fetched(self, summary_json):
     def handler(request):
-      return httpx.Response(
-        200, text=summary_json, request=request,
+      return httpx2.Response(
+        200,
+        text=summary_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSSummaryFetch()
     assert fetcher.fetched() is None
@@ -83,12 +91,14 @@ class TestZSSummaryFetch:
 
   def test_json_output(self, summary_json):
     def handler(request):
-      return httpx.Response(
-        200, text=summary_json, request=request,
+      return httpx2.Response(
+        200,
+        text=summary_json,
+        request=request,
       )
 
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSSummaryFetch()
     fetcher.fetch()
@@ -99,13 +109,15 @@ class TestZSSummaryFetch:
 
   def test_sync_mode(self, summary_json):
     def handler(request):
-      return httpx.Response(
-        200, text=summary_json, request=request,
+      return httpx2.Response(
+        200,
+        text=summary_json,
+        request=request,
       )
 
     ZSSummaryFetch.set_sync_mode(True)
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSSummaryFetch()
     result = fetcher.fetch()
@@ -114,14 +126,17 @@ class TestZSSummaryFetch:
   @pytest.mark.anyio
   async def test_afetch_summary(self, summary_json):
     async def handler(request):
-      return httpx.Response(
-        200, text=summary_json, request=request,
+      return httpx2.Response(
+        200,
+        text=summary_json,
+        request=request,
       )
 
     from zsdatafetch.async_zs import AsyncZS_obj
+
     zs = AsyncZS_obj()
-    zs._client = httpx.AsyncClient(
-      transport=httpx.MockTransport(handler),
+    zs._client = httpx2.AsyncClient(
+      transport=httpx2.MockTransport(handler),
     )
     fetcher = ZSSummaryFetch()
     fetcher.set_session(zs)

--- a/test/test_zsdatafetch/test_zs_obj.py
+++ b/test/test_zsdatafetch/test_zs_obj.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from shared.exceptions import NetworkError
@@ -22,7 +22,7 @@ class TestZSObj:
   def test_get_client_creates_shared_client(self):
     client = ZS_obj.get_client()
     assert client is not None
-    assert isinstance(client, httpx.Client)
+    assert isinstance(client, httpx2.Client)
     # Second call returns same instance
     assert ZS_obj.get_client() is client
 
@@ -41,7 +41,7 @@ class TestZSObj:
     test_data = {'status': {'indicator': 'none'}}
 
     def handler(request):
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text=json.dumps(test_data),
         request=request,
@@ -49,34 +49,34 @@ class TestZSObj:
 
     obj = ZS_obj()
     # Replace the client with a mock transport
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     result = obj.fetch_json('/summary.json')
     assert json.loads(result) == test_data
 
   def test_fetch_json_http_error(self):
     def handler(request):
-      return httpx.Response(
+      return httpx2.Response(
         500,
         text='Internal Server Error',
         request=request,
       )
 
     obj = ZS_obj()
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     with pytest.raises(NetworkError):
       obj.fetch_json('/summary.json')
 
   def test_fetch_json_network_error(self):
     def handler(request):
-      raise httpx.ConnectError('Connection refused')
+      raise httpx2.ConnectError('Connection refused')
 
     obj = ZS_obj()
-    ZS_obj._client = httpx.Client(
-      transport=httpx.MockTransport(handler),
+    ZS_obj._client = httpx2.Client(
+      transport=httpx2.MockTransport(handler),
     )
     with pytest.raises(NetworkError):
       obj.fetch_json('/summary.json')
@@ -90,15 +90,15 @@ class TestAsyncZSObj:
     test_data = {'status': {'indicator': 'none'}}
 
     async def handler(request):
-      return httpx.Response(
+      return httpx2.Response(
         200,
         text=json.dumps(test_data),
         request=request,
       )
 
     obj = AsyncZS_obj()
-    obj._client = httpx.AsyncClient(
-      transport=httpx.MockTransport(handler),
+    obj._client = httpx2.AsyncClient(
+      transport=httpx2.MockTransport(handler),
     )
     result = await obj.fetch_json('/summary.json')
     assert json.loads(result) == test_data
@@ -107,15 +107,15 @@ class TestAsyncZSObj:
   @pytest.mark.anyio
   async def test_async_fetch_json_error(self):
     async def handler(request):
-      return httpx.Response(
+      return httpx2.Response(
         500,
         text='Error',
         request=request,
       )
 
     obj = AsyncZS_obj()
-    obj._client = httpx.AsyncClient(
-      transport=httpx.MockTransport(handler),
+    obj._client = httpx2.AsyncClient(
+      transport=httpx2.MockTransport(handler),
     )
     with pytest.raises(NetworkError):
       await obj.fetch_json('/summary.json')

--- a/uv.lock
+++ b/uv.lock
@@ -645,7 +645,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -766,40 +766,41 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
     { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "httpcore2" },
     { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -846,17 +847,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -871,18 +872,18 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -894,7 +895,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1593,6 +1594,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.39"
 source = { registry = "https://pypi.org/simple" }
@@ -1683,13 +1693,13 @@ wheels = [
 
 [[package]]
 name = "zpdatafetch"
-version = "2.2.5"
+version = "2.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
     { name = "beautifulsoup4" },
     { name = "cryptography" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "idna" },
     { name = "keyring" },
     { name = "keyrings-alt" },
@@ -1727,7 +1737,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.4.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "httpx2", specifier = ">=2.9.1" },
     { name = "idna", specifier = ">=3.16" },
     { name = "keyring", specifier = ">=25.2.0" },
     { name = "keyrings-alt" },


### PR DESCRIPTION
httpx -> httpx2 (Pydantic's maintained fork, on httpcore2) across all packages and tests. Drop the obsolete Python 3.14 httpcore xfail markers: httpcore2 resolves the typing.Union incompatibility, so those tests now pass normally.

All 772 non-live tests pass on Python 3.14.